### PR TITLE
Add new entries to preferences and fix bug

### DIFF
--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -39,6 +39,7 @@ export const MoorhenFileMenu = (props) => {
 
     const readPdbFile = (file) => {
         const newMolecule = new MoorhenMolecule(commandCentre, props.urlPrefix)
+        newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         return newMolecule.loadToCootFromFile(file)
     }
 
@@ -83,6 +84,7 @@ export const MoorhenFileMenu = (props) => {
 
     const fetchMoleculeFromURL = (url, molName) => {
         const newMolecule = new MoorhenMolecule(commandCentre, props.urlPrefix)
+        newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         return new Promise(async () => {
             try {
                 await newMolecule.loadToCootFromURL(url, molName)

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -10,8 +10,8 @@ export const MoorhenMapCard = (props) => {
     const [cootContour, setCootContour] = useState(true)
     const [mapRadius, setMapRadius] = useState(props.initialRadius)
     const [mapContourLevel, setMapContourLevel] = useState(props.initialContour)
-    const [mapLitLines, setMapLitLines] = useState(props.defaultLitLines)
-    const [mapSolid, setMapSolid] = useState(false)
+    const [mapLitLines, setMapLitLines] = useState(props.defaultMapLitLines)
+    const [mapSolid, setMapSolid] = useState(props.defaultMapSurface)
     const [isCollapsed, setIsCollapsed] = useState(!props.defaultExpandDisplayCards);
     const [currentName, setCurrentName] = useState(props.map.name);
     const nextOrigin = createRef([])
@@ -214,7 +214,8 @@ export const MoorhenMapCard = (props) => {
     useEffect(() => {
         setCootContour(props.map.cootContour)
         setMapContourLevel(props.initialContour)
-        setMapLitLines(props.defaultLitLines)
+        setMapLitLines(props.defaultMapLitLines)
+        setMapSolid(props.defaultMapSurface)
         setMapRadius(props.initialRadius)
     }, [])
 

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -213,14 +213,6 @@ export const MoorhenMapCard = (props) => {
 
     useEffect(() => {
         setCootContour(props.map.cootContour)
-        setMapContourLevel(props.initialContour)
-        setMapLitLines(props.defaultMapLitLines)
-        setMapSolid(props.defaultMapSurface)
-        setMapRadius(props.initialRadius)
-    }, [])
-
-    useEffect(() => {
-        setCootContour(props.map.cootContour)
         if (props.map.cootContour && !busyContouring.current) {
             busyContouring.current = true
             console.log(props.commandCentre.current)
@@ -276,12 +268,12 @@ export const MoorhenMapCard = (props) => {
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringLevel" className="mb-3">
-                            <MoorhenSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" isDisabled={!cootContour} intialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
+                        <MoorhenSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" isDisabled={!cootContour} intialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
                     </Form.Group>
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringRadius" className="mb-3">
-                            <MoorhenSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" isDisabled={!cootContour} intialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
+                        <MoorhenSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" isDisabled={!cootContour} intialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
                     </Form.Group>
                 </Col>
             </Row>

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -109,6 +109,7 @@ export const MoorhenLoadTutorialDataMenuItem = (props) => {
         const tutorialNumber = tutorialNumberSelectorRef.current.value
         console.log(`Loading data for tutorial number ${tutorialNumber}`)
         const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+        newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         const newMap = new MoorhenMap(props.commandCentre)
         const newDiffMap = new MoorhenMap(props.commandCentre)
         newMolecule.loadToCootFromURL(`${props.urlPrefix}/baby-gru/tutorials/moorhen-tutorial-structure-number-${tutorialNumber}.pdb`, `moorhen-tutorial-${tutorialNumber}`)
@@ -173,6 +174,7 @@ export const MoorhenGetMonomerMenuItem = (props) => {
                     const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                     newMolecule.molNo = result.data.result.result
                     newMolecule.name = tlcRef.current.value
+                    newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
                     return newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef).then(_ => {
                         props.changeMolecules({ action: "Add", item: newMolecule })
                         props.setPopoverIsShown(false)
@@ -227,6 +229,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
                         const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                         newMolecule.molNo = iMol
                         newMolecule.name = `lig_${iMol}`
+                        newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
                         return newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef).then(_ => {
                             props.changeMolecules({ action: "Add", item: newMolecule })
                         })
@@ -357,6 +360,35 @@ export const MoorhenRotateTranslateMoleculeMenuItem = (props) => {
         setPopoverIsShown={props.setPopoverIsShown}
     />
 }
+
+export const MoorhenDefaultBondSmoothnessPreferencesMenuItem = (props) => {
+    const smoothnesSelectRef = useRef(null)
+
+    const onCompleted = () => {
+        props.setDefaultBondSmoothness(parseInt(smoothnesSelectRef.current.value))
+    }
+    
+    const panelContent =
+        <>
+            <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenSmoothnessSelector">
+                <Form.Label>Smoothness</Form.Label>
+                <FormSelect size="sm" ref={smoothnesSelectRef} defaultValue={props.defaultBondSmoothness}>
+                    <option value={1} key={1}>Coarse</option>
+                    <option value={2} key={2}>Nice</option>
+                    <option value={3} key={3}>Smooth</option>
+                </FormSelect>
+            </Form.Group>
+        </>
+
+    return <MoorhenMenuItem
+        popoverPlacement='right'
+        popoverContent={panelContent}
+        menuItemText={"Default quality of molecule bonds"}
+        setPopoverIsShown={props.setPopoverIsShown}
+        onCompleted={onCompleted}
+    />
+}
+
 
 export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
     const smoothnesSelectRef = useRef(null)
@@ -606,6 +638,7 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
                                 newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                                 newMolecule.molNo = result.data.result.result
                                 newMolecule.name = instanceName
+                                newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
                                 newMolecule.addDict(fileContent)
                                 props.changeMolecules({ action: "Add", item: newMolecule })
                                 return newMolecule.fetchIfDirtyAndDraw("CBs", props.glRef)
@@ -1191,6 +1224,7 @@ export const MoorhenCopyFragmentUsingCidMenuItem = (props) => {
             const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
             newMolecule.name = `${fromMolecules[0].name} fragment`
             newMolecule.molNo = response.data.result.result
+            newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
             await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
             props.changeMolecules({ action: "Add", item: newMolecule })
         })

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -389,7 +389,6 @@ export const MoorhenDefaultBondSmoothnessPreferencesMenuItem = (props) => {
     />
 }
 
-
 export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
     const smoothnesSelectRef = useRef(null)
 

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -383,7 +383,7 @@ export const MoorhenDefaultBondSmoothnessPreferencesMenuItem = (props) => {
     return <MoorhenMenuItem
         popoverPlacement='right'
         popoverContent={panelContent}
-        menuItemText={"Default quality of molecule bonds"}
+        menuItemText={"Default smoothness of molecule bonds"}
         setPopoverIsShown={props.setPopoverIsShown}
         onCompleted={onCompleted}
     />

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -14,7 +14,7 @@ export const MoorhenMoleculeCard = (props) => {
     const [isVisible, setIsVisible] = useState(true)
     const [bondWidth, setBondWidth] = useState(0.1)
     const [atomRadiusBondRatio, setAtomRadiusBondRatio] = useState(1.5)
-    const [bondSmoothness, setBondSmoothness] = useState(1)
+    const [bondSmoothness, setBondSmoothness] = useState(props.defaultBondSmoothness)
 
     const bondSettingsProps = {
         bondWidth, setBondWidth, atomRadiusBondRatio,

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -54,10 +54,12 @@ export const MoorhenMoleculeCard = (props) => {
             return
         }
 
-        props.molecule.cootBondsOptions.smoothness = bondSmoothness
-        if (isVisible && showState['CBs']) {
+        if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.smoothness !== bondSmoothness) {
+            props.molecule.cootBondsOptions.smoothness = bondSmoothness
             props.molecule.setAtomsDirty(true)
             props.molecule.redraw(props.glRef)
+        } else {
+            props.molecule.cootBondsOptions.smoothness = bondSmoothness
         }
 
     }, [bondSmoothness]);
@@ -67,10 +69,12 @@ export const MoorhenMoleculeCard = (props) => {
             return
         }
 
-        props.molecule.cootBondsOptions.width = bondWidth
-        if (isVisible && showState['CBs']) {
+        if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.width !== bondWidth) {
+            props.molecule.cootBondsOptions.width = bondWidth
             props.molecule.setAtomsDirty(true)
             props.molecule.redraw(props.glRef)
+        } else {
+            props.molecule.cootBondsOptions.width = bondWidth
         }
 
     }, [bondWidth]);
@@ -80,10 +84,12 @@ export const MoorhenMoleculeCard = (props) => {
             return
         }
 
-        props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
-        if (isVisible && showState['CBs']) {
+        if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.atomRadiusBondRatio !== atomRadiusBondRatio) {
+            props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
             props.molecule.setAtomsDirty(true)
             props.molecule.redraw(props.glRef)
+        } else {
+            props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
         }
 
     }, [atomRadiusBondRatio]);

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -99,11 +99,6 @@ export const MoorhenPreferencesMenu = (props) => {
                             onChange={() => { setDefaultBondSmoothness(!drawMissingLoops) }}
                             label="Default quality of molecule bonds"/>
                     </InputGroup>
-                    <MoorhenDefaultBondSmoothnessPreferencesMenuItem
-                        defaultBondSmoothness={defaultBondSmoothness}
-                        setDefaultBondSmoothness={setDefaultBondSmoothness}
-                        setPopoverIsShown={setPopoverIsShown}
-                    />
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 
                             type="switch"
@@ -111,6 +106,11 @@ export const MoorhenPreferencesMenu = (props) => {
                             onChange={() => { setMakeBackups(!makeBackups) }}
                             label="Make molecule backups"/>
                     </InputGroup>
+                    <MoorhenDefaultBondSmoothnessPreferencesMenuItem
+                        defaultBondSmoothness={defaultBondSmoothness}
+                        setDefaultBondSmoothness={setDefaultBondSmoothness}
+                        setPopoverIsShown={setPopoverIsShown}
+                    />
                     <hr></hr>
                     <Form.Group controlId="mouseSensitivitySlider" style={{paddingTop:'0rem', paddingBottom:'0.5rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
                         <MoorhenSlider minVal={0.1} maxVal={10.0} logScale={false} sliderTitle="Mouse sensitivity" intialValue={2.5} externalValue={mouseSensitivity} setExternalValue={setMouseSensitivity}/>

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -8,11 +8,11 @@ import MoorhenSlider from './MoorhenSlider'
 export const MoorhenPreferencesMenu = (props) => {
     const { 
         atomLabelDepthMode, setAtomLabelDepthMode, darkMode, setDarkMode, 
-        defaultExpandDisplayCards, setDefaultExpandDisplayCards, defaultLitLines,
-        setDefaultLitLines, refineAfterMod, setRefineAfterMod, mouseSensitivity,
+        defaultExpandDisplayCards, setDefaultExpandDisplayCards, defaultMapLitLines,
+        setDefaultMapLitLines, refineAfterMod, setRefineAfterMod, mouseSensitivity,
         setMouseSensitivity, drawCrosshairs, setDrawCrosshairs, drawMissingLoops,
         setDrawMissingLoops, mapLineWidth, setMapLineWidth, makeBackups, setMakeBackups,
-        showShortcutToast, setShowShortcutToast
+        showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface
      } = props;
     const [showModal, setShowModal] = useState(null);
 
@@ -49,9 +49,16 @@ export const MoorhenPreferencesMenu = (props) => {
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 
                             type="switch"
-                            checked={defaultLitLines}
-                            onChange={() => { setDefaultLitLines(!defaultLitLines) }}
+                            checked={defaultMapLitLines}
+                            onChange={() => { setDefaultMapLitLines(!defaultMapLitLines) }}
                             label="Activate map lit lines by default"/>
+                    </InputGroup>
+                    <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                        <Form.Check 
+                            type="switch"
+                            checked={defaultMapSurface}
+                            onChange={() => { setDefaultMapSurface(!defaultMapSurface) }}
+                            label="Show maps as surface by default"/>
                     </InputGroup>
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -3,6 +3,7 @@ import { NavDropdown, Form, InputGroup } from "react-bootstrap";
 import { MoorhenShortcutConfigModal } from "./MoorhenShortcutConfigModal"
 import { MenuItem } from "@mui/material";
 import { convertViewtoPx } from "../utils/MoorhenUtils";
+import { MoorhenDefaultBondSmoothnessPreferencesMenuItem } from './MoorhenMenuItem'
 import MoorhenSlider from './MoorhenSlider' 
 
 export const MoorhenPreferencesMenu = (props) => {
@@ -12,15 +13,18 @@ export const MoorhenPreferencesMenu = (props) => {
         setDefaultMapLitLines, refineAfterMod, setRefineAfterMod, mouseSensitivity,
         setMouseSensitivity, drawCrosshairs, setDrawCrosshairs, drawMissingLoops,
         setDrawMissingLoops, mapLineWidth, setMapLineWidth, makeBackups, setMakeBackups,
-        showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface
+        showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface,
+        defaultBondSmoothness, setDefaultBondSmoothness
      } = props;
-    const [showModal, setShowModal] = useState(null);
+
+     const [showModal, setShowModal] = useState(null);
+    const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     return <NavDropdown
                     title="Preferences"
                     id="preferences-nav-dropdown"
                     style={{display:'flex', alignItems:'center'}}
-                    autoClose="outside"
+                    autoClose={popoverIsShown ? false : 'outside'}
                     show={props.currentDropdownId === props.dropdownId}
                     onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
                 <div style={{maxHeight: convertViewtoPx(65, props.windowHeight), overflowY: 'auto'}}>
@@ -88,6 +92,18 @@ export const MoorhenPreferencesMenu = (props) => {
                             onChange={() => { setDrawMissingLoops(!drawMissingLoops) }}
                             label="Show missing loops"/>
                     </InputGroup>
+                    <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                        <Form.Check 
+                            type="switch"
+                            checked={drawMissingLoops}
+                            onChange={() => { setDefaultBondSmoothness(!drawMissingLoops) }}
+                            label="Default quality of molecule bonds"/>
+                    </InputGroup>
+                    <MoorhenDefaultBondSmoothnessPreferencesMenuItem
+                        defaultBondSmoothness={defaultBondSmoothness}
+                        setDefaultBondSmoothness={setDefaultBondSmoothness}
+                        setPopoverIsShown={setPopoverIsShown}
+                    />
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 
                             type="switch"

--- a/baby-gru/src/components/MoorhenSlider.js
+++ b/baby-gru/src/components/MoorhenSlider.js
@@ -22,10 +22,6 @@ export default function MoorhenSlider(props) {
         }
     }, [externalValue])
 
-    React.useEffect(() => {
-        handleChange(null, convertInitValueToScale(props.externalValue))
-    }, [])
-
     const handleChange = (event, newValue) => {
         setValue(newValue);
         if (props.logScale) {

--- a/baby-gru/src/components/MoorhenSlider.js
+++ b/baby-gru/src/components/MoorhenSlider.js
@@ -14,11 +14,12 @@ export default function MoorhenSlider(props) {
     }
 
     const [value, setValue] = React.useState(convertInitValueToScale(props.intialValue));
-    const setValueTimer = React.createRef(null)
-    const [externalValue, setExternalValue] = React.useState(5)
+    const [externalValue, setExternalValue] = React.useState(props.externalValue)
 
     React.useEffect(() => {
-        props.setExternalValue(parseFloat(externalValue))
+        if (props.externalValue !== parseFloat(externalValue)) {
+            props.setExternalValue(parseFloat(externalValue))
+        }
     }, [externalValue])
 
     React.useEffect(() => {

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -137,6 +137,7 @@ MoorhenMolecule.prototype.copyMolecule = async function (glRef) {
     let moleculeAtoms = await this.getAtoms()
     let newMolecule = new MoorhenMolecule(this.commandCentre, this.urlPrefix)
     newMolecule.name = `${this.name}-placeholder`
+    newMolecule.cootBondsOptions = this.cootBondsOptions
 
     let response = await this.commandCentre.current.cootCommand({
         returnType: "status",
@@ -160,6 +161,7 @@ MoorhenMolecule.prototype.copyFragment = async function (chainId, res_no_start, 
     const newMolecule = new MoorhenMolecule($this.commandCentre, $this.urlPrefix)
     newMolecule.name = `${$this.name} fragment`
     newMolecule.molNo = response.data.result
+    newMolecule.cootBondsOptions = $this.cootBondsOptions
     await newMolecule.fetchIfDirtyAndDraw('CBs', glRef)
     if (doRecentre) await newMolecule.centreOn(glRef)
 
@@ -1082,6 +1084,7 @@ MoorhenMolecule.prototype.addLigandOfType = async function (resType, at, glRef) 
                 newMolecule.setAtomsDirty(true)
                 newMolecule.molNo = result.data.result.result
                 newMolecule.name = resType.toUpperCase()
+                newMolecule.cootBondsOptions = $this.cootBondsOptions
                 const _ = await $this.mergeMolecules([newMolecule], glRef, true);
                 return newMolecule.delete(glRef);
             }

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -12,7 +12,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.7',
+        version: '0.0.8',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -16,7 +16,7 @@ const getDefaultValues = () => {
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
-        defaultLitLines: false,
+        defaultMapLitLines: false,
         refineAfterMod: true,
         drawCrosshairs: true,
         drawMissingLoops: true,
@@ -24,6 +24,7 @@ const getDefaultValues = () => {
         mapLineWidth: 1.0,
         makeBackups: true,
         showShortcutToast: true,
+        defaultMapSurface: true,
         shortCuts: {
             "sphere_refine": {
                 modifiers: ["shiftKey"],
@@ -137,7 +138,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [atomLabelDepthMode, setAtomLabelDepthMode] = useState(null)
     const [defaultExpandDisplayCards, setDefaultExpandDisplayCards] = useState(null)
     const [shortCuts, setShortCuts] = useState(null)
-    const [defaultLitLines, setDefaultLitLines] = useState(null)
+    const [defaultMapLitLines, setDefaultMapLitLines] = useState(null)
     const [refineAfterMod, setRefineAfterMod] = useState(null)
     const [mouseSensitivity, setMouseSensitivity] = useState(null)
     const [drawCrosshairs, setDrawCrosshairs] = useState(null)
@@ -145,6 +146,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [mapLineWidth, setMapLineWidth] = useState(null)
     const [makeBackups, setMakeBackups] = useState(null)
     const [showShortcutToast, setShowShortcutToast] = useState(null)
+    const [defaultMapSurface, setDefaultMapSurface] = useState(null)
 
     const restoreDefaults = (defaultValues)=> {
         updateStoredPreferences('version', defaultValues.version)
@@ -152,7 +154,7 @@ const PreferencesContextProvider = ({ children }) => {
         setDefaultExpandDisplayCards(defaultValues.defaultExpandDisplayCards)            
         setShortCuts(JSON.stringify(defaultValues.shortCuts))            
         setAtomLabelDepthMode(defaultValues.atomLabelDepthMode)
-        setDefaultLitLines(defaultValues.defaultLitLines)
+        setDefaultMapLitLines(defaultValues.defaultMapLitLines)
         setRefineAfterMod(defaultValues.refineAfterMod)
         setMouseSensitivity(defaultValues.mouseSensitivity)
         setDrawCrosshairs(defaultValues.drawCrosshairs)
@@ -160,6 +162,7 @@ const PreferencesContextProvider = ({ children }) => {
         setMapLineWidth(defaultValues.mapLineWidth)
         setMakeBackups(defaultValues.makeBackups)
         setShowShortcutToast(defaultValues.showShortcutToast)
+        setDefaultMapSurface(defaultValues.defaultMapSurface)
     }
 
     /**
@@ -177,14 +180,15 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('defaultExpandDisplayCards'),
                     localforage.getItem('shortCuts'),
                     localforage.getItem('atomLabelDepthMode'),
-                    localforage.getItem('defaultLitLines'),
+                    localforage.getItem('defaultMapLitLines'),
                     localforage.getItem('refineAfterMod'),
                     localforage.getItem('mouseSensitivity'),
                     localforage.getItem('drawCrosshairs'),
                     localforage.getItem('drawMissingLoops'),
                     localforage.getItem('mapLineWidth'),
                     localforage.getItem('makeBackups'),
-                    localforage.getItem('showShortcutToast')
+                    localforage.getItem('showShortcutToast'),
+                    localforage.getItem('defaultMapSurface')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -202,7 +206,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setDefaultExpandDisplayCards(response[2])
                     setShortCuts(response[3])
                     setAtomLabelDepthMode(response[4])
-                    setDefaultLitLines(response[5])
+                    setDefaultMapLitLines(response[5])
                     setRefineAfterMod(response[6])
                     setMouseSensitivity(response[7])
                     setDrawCrosshairs(response[8])
@@ -210,6 +214,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setMapLineWidth(response[10])
                     setMakeBackups(response[11])
                     setShowShortcutToast(response[12])
+                    setDefaultMapSurface(response[13])
                 }                
                 
             } catch (err) {
@@ -235,6 +240,15 @@ const PreferencesContextProvider = ({ children }) => {
        
         updateStoredPreferences('showShortcutToast', showShortcutToast);
     }, [showShortcutToast]);
+
+    useMemo(() => {
+
+        if (defaultMapSurface === null) {
+            return
+        }
+       
+        updateStoredPreferences('defaultMapSurface', defaultMapSurface);
+    }, [defaultMapSurface]);
 
     useMemo(() => {
 
@@ -328,19 +342,20 @@ const PreferencesContextProvider = ({ children }) => {
 
     useMemo(() => {
 
-        if (defaultLitLines === null) {
+        if (defaultMapLitLines === null) {
             return
         }
        
-        updateStoredPreferences('defaultLitLines', defaultLitLines);
-    }, [defaultLitLines]);
+        updateStoredPreferences('defaultMapLitLines', defaultMapLitLines);
+    }, [defaultMapLitLines]);
 
     const collectedContextValues = {
         darkMode, setDarkMode, atomLabelDepthMode, setAtomLabelDepthMode, defaultExpandDisplayCards,
-        setDefaultExpandDisplayCards, shortCuts, setShortCuts, defaultLitLines, setDefaultLitLines,
+        setDefaultExpandDisplayCards, shortCuts, setShortCuts, defaultMapLitLines, setDefaultMapLitLines,
         refineAfterMod, setRefineAfterMod, mouseSensitivity, setMouseSensitivity, drawCrosshairs, 
         setDrawCrosshairs, drawMissingLoops, setDrawMissingLoops, mapLineWidth, setMapLineWidth,
-        makeBackups, setMakeBackups, showShortcutToast, setShowShortcutToast
+        makeBackups, setMakeBackups, showShortcutToast, setShowShortcutToast, defaultMapSurface,
+        setDefaultMapSurface
     }
 
     return (

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -24,7 +24,7 @@ const getDefaultValues = () => {
         mapLineWidth: 1.0,
         makeBackups: true,
         showShortcutToast: true,
-        defaultMapSurface: true,
+        defaultMapSurface: false,
         defaultBondSmoothness: 1,
         shortCuts: {
             "sphere_refine": {

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -25,6 +25,7 @@ const getDefaultValues = () => {
         makeBackups: true,
         showShortcutToast: true,
         defaultMapSurface: true,
+        defaultBondSmoothness: 1,
         shortCuts: {
             "sphere_refine": {
                 modifiers: ["shiftKey"],
@@ -147,6 +148,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [makeBackups, setMakeBackups] = useState(null)
     const [showShortcutToast, setShowShortcutToast] = useState(null)
     const [defaultMapSurface, setDefaultMapSurface] = useState(null)
+    const [defaultBondSmoothness, setDefaultBondSmoothness] = useState(null)
 
     const restoreDefaults = (defaultValues)=> {
         updateStoredPreferences('version', defaultValues.version)
@@ -163,6 +165,7 @@ const PreferencesContextProvider = ({ children }) => {
         setMakeBackups(defaultValues.makeBackups)
         setShowShortcutToast(defaultValues.showShortcutToast)
         setDefaultMapSurface(defaultValues.defaultMapSurface)
+        setDefaultBondSmoothness(defaultValues.defaultBondSmoothness)
     }
 
     /**
@@ -188,7 +191,8 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('mapLineWidth'),
                     localforage.getItem('makeBackups'),
                     localforage.getItem('showShortcutToast'),
-                    localforage.getItem('defaultMapSurface')
+                    localforage.getItem('defaultMapSurface'),
+                    localforage.getItem('defaultBondSmoothness')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -215,6 +219,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setMakeBackups(response[11])
                     setShowShortcutToast(response[12])
                     setDefaultMapSurface(response[13])
+                    setDefaultBondSmoothness(response[14])
                 }                
                 
             } catch (err) {
@@ -240,6 +245,15 @@ const PreferencesContextProvider = ({ children }) => {
        
         updateStoredPreferences('showShortcutToast', showShortcutToast);
     }, [showShortcutToast]);
+    
+    useMemo(() => {
+
+        if (defaultBondSmoothness === null) {
+            return
+        }
+       
+        updateStoredPreferences('defaultBondSmoothness', defaultBondSmoothness);
+    }, [defaultBondSmoothness]);
 
     useMemo(() => {
 
@@ -355,7 +369,7 @@ const PreferencesContextProvider = ({ children }) => {
         refineAfterMod, setRefineAfterMod, mouseSensitivity, setMouseSensitivity, drawCrosshairs, 
         setDrawCrosshairs, drawMissingLoops, setDrawMissingLoops, mapLineWidth, setMapLineWidth,
         makeBackups, setMakeBackups, showShortcutToast, setShowShortcutToast, defaultMapSurface,
-        setDefaultMapSurface
+        setDefaultMapSurface, defaultBondSmoothness, setDefaultBondSmoothness
     }
 
     return (


### PR DESCRIPTION
This update adds "show maps as surfaces by default" and "default molecule bond smoothness" to the preferences menu. Also, a bug resulting from the interaction between `MoorhenMapCard` and `MoorhenSlider` that resulted in `get_map_contours_mesh` being called twice on map load has been fixed.