### PR TITLE
Refactor map event listeners into a single mapUpdate event

### DIFF
--- a/baby-gru/src/components/MoorhenFillMissingAtoms.js
+++ b/baby-gru/src/components/MoorhenFillMissingAtoms.js
@@ -16,7 +16,6 @@ export const MoorhenFillMissingAtoms = (props) => {
 
     const handleAtomFill = (...args) => {
         const fillPartialResidue = async (selectedMolecule, chainId, resNum, insCode) => {
-            console.log('HIIIII')
             console.log(selectedMolecule, chainId, resNum, insCode)
             await props.commandCentre.current.cootCommand({
                 returnType: "status",
@@ -36,9 +35,8 @@ export const MoorhenFillMissingAtoms = (props) => {
             }
             selectedMolecule.setAtomsDirty(true)
             selectedMolecule.redraw(props.glRef)
-            const originChangedEvent = new CustomEvent("originChanged",
-                { "detail": props.glRef.current.origin });
-            document.dispatchEvent(originChangedEvent);    
+            const mapUpdateEvent = new CustomEvent("mapUpdate", { "detail": props.glRef.current.origin })
+            document.dispatchEvent(mapUpdateEvent);    
         }
         if (args.every(arg => arg !== null)) {
             fillPartialResidue(...args)

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -9,8 +9,8 @@ const apresEdit = (molecule, glRef, setHoveredAtom) => {
     molecule.setAtomsDirty(true)
     molecule.redraw(glRef)
     setHoveredAtom({ molecule: null, cid: null })
-    const originChangedEvent = new CustomEvent("originChanged", { "detail": glRef.current.origin })
-    document.dispatchEvent(originChangedEvent)
+    const mapUpdateEvent = new CustomEvent("mapUpdate", { "detail": glRef.current.origin })
+    document.dispatchEvent(mapUpdateEvent)
 }
 
 export const babyGruKeyPress = (event, collectedProps, shortCuts) => {

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -137,19 +137,18 @@ export const MoorhenMapCard = (props) => {
                         {isCollapsed ? < ExpandMoreOutlined/> : <ExpandLessOutlined />}
                     </Button>
                 </Fragment>
-
     }
 
-    const handleOriginCallback = useCallback(e => {
+    const handleUpdateMapCallback = useCallback(e => {
+        props.map.contourLevel = mapContourLevel
         nextOrigin.current = [...e.detail.map(coord => -coord)]
         if (props.map.cootContour) {
             if (busyContouring.current) {
-                console.log('Skipping originChanged ', nextOrigin.current)
-            }
-            else {
+                console.log('Skipping map update because already busy ', nextOrigin.current)
+            } else {
+                console.log(mapContourLevel)
                 props.map.contourLevel = mapContourLevel
                 busyContouring.current = true
-                props.commandCentre.current.extendConsoleMessage("Because contourLevel or mapRadius changed useCallback")
                 props.map.doCootContour(props.glRef,
                     ...nextOrigin.current,
                     mapRadius,
@@ -180,27 +179,6 @@ export const MoorhenMapCard = (props) => {
         }
     }, [props.map.molNo])
 
-    const handleContourLevelCallback = useCallback(e => {
-        props.map.contourLevel = mapContourLevel
-        nextOrigin.current = [...e.detail.map(coord => -coord)]
-        if (props.map.cootContour) {
-            if (busyContouring.current) {
-                console.log('Skipping originChanged ', nextOrigin.current)
-            }
-            else {
-                props.map.contourLevel = mapContourLevel
-                busyContouring.current = true
-                props.map.doCootContour(props.glRef,
-                    ...nextOrigin.current,
-                    mapRadius,
-                    props.map.contourLevel)
-                    .then(result => {
-                        busyContouring.current = false
-                    })
-            }
-        }
-    }, [mapContourLevel, mapRadius])
-
     useMemo(() => {
         if (currentName === "") {
             return
@@ -210,17 +188,15 @@ export const MoorhenMapCard = (props) => {
     }, [currentName]);
 
     useEffect(() => {
-        document.addEventListener("originChanged", handleOriginCallback);
-        document.addEventListener("contourLevelChanged", handleContourLevelCallback);
+        document.addEventListener("mapUpdate", handleUpdateMapCallback);
         document.addEventListener("wheelContourLevelChanged", handleWheelContourLevelCallback);
         document.addEventListener("contourOnSessionLoad", handleContourOnSessionLoad);
         return () => {
-            document.removeEventListener("originChanged", handleOriginCallback);
-            document.removeEventListener("contourLevelChanged", handleContourLevelCallback);
+            document.removeEventListener("mapUpdate", handleUpdateMapCallback);
             document.removeEventListener("wheelContourLevelChanged", handleWheelContourLevelCallback);
             document.removeEventListener("contourOnSessionLoad", handleContourOnSessionLoad);
         };
-    }, [handleOriginCallback, props.activeMap?.molNo]);
+    }, [handleUpdateMapCallback, props.activeMap?.molNo]);
 
     useEffect(() => {
         props.map.setAlpha(mapOpacity,props.glRef)

--- a/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
@@ -61,10 +61,8 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
             const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)
             selectedMolecule.setAtomsDirty(true)
             selectedMolecule.redraw(props.glRef)
-            //Here use originChanged event to force recontour (relevant for live updating maps)
-            const originChangedEvent = new CustomEvent("originChanged",
-                { "detail": props.glRef.current.origin });
-            document.dispatchEvent(originChangedEvent);
+            const mapUpdateEvent = new CustomEvent("mapUpdate", { "detail": props.glRef.current.origin });
+            document.dispatchEvent(mapUpdateEvent);
         }
 
         if (args.every(arg => arg !== null)) {

--- a/baby-gru/src/components/MoorhenSimpleEditButton.js
+++ b/baby-gru/src/components/MoorhenSimpleEditButton.js
@@ -68,10 +68,9 @@ const MoorhenSimpleEditButton = forwardRef((props, buttonRef) => {
                         }
                         molecule.setAtomsDirty(true)
                         molecule.redraw(props.glRef)
-                        //Here use originChanged event to force recontour (relevant for live updating maps)
-                        const originChangedEvent = new CustomEvent("originChanged",
-                            { "detail": props.glRef.current.origin });
-                        document.dispatchEvent(originChangedEvent);
+
+                        const mapUpdateEvent = new CustomEvent("mapUpdate", { "detail": props.glRef.current.origin });
+                        document.dispatchEvent(mapUpdateEvent);
 
                         if(props.onExit) {
                             props.onExit(molecule, chosenAtom, result)

--- a/react-app/src/mgWebGL.js
+++ b/react-app/src/mgWebGL.js
@@ -3106,8 +3106,8 @@ class MGWebGL extends Component {
 
     setOrigin(o, doDrawScene) {
         this.origin = o;
-        const originChangedEvent = new CustomEvent("originChanged", { "detail": this.origin });
-        document.dispatchEvent(originChangedEvent);
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { "detail": this.origin });
+        document.dispatchEvent(mapUpdateEvent);
         //default is to drawScene, unless doDrawScene provided and value is false
         if (typeof doDrawScene === 'undefined' || doDrawScene === true) {
             this.drawScene();


### PR DESCRIPTION
This greatly simplifies some of the code in `MoorhenMapCard` by refactoring several event listeners that trigger a map re-contour into a single mapUpdate event. This also simplifies the code necessary to know when to pull rfactor/rail points from the api as there is only one event type now after a model update.