### PR TITLE
Control scores in preferences and use sfcalc_genmaps_using_bulk_solvent

### DIFF
--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -939,23 +939,33 @@ export const MoorhenImportFSigFMenuItem = (props) => {
     const moleculeSelectRef = useRef(null)
 
     const connectMap = async () => {
-        const commandArgs = [
+        const connectMapsArgs = [
             parseInt(moleculeSelectRef.current.value),
             parseInt(mapSelectRef.current.value),
             parseInt(twoFoFcSelectRef.current.value),
             parseInt(foFcSelectRef.current.value),
         ]
+        const sFcalcArgs = [
+            parseInt(moleculeSelectRef.current.value),
+            parseInt(twoFoFcSelectRef.current.value),
+            parseInt(foFcSelectRef.current.value),
+            parseInt(mapSelectRef.current.value)
+        ]
         
-        if (commandArgs.every(arg => !isNaN(arg))) {
+        if (connectMapsArgs.every(arg => !isNaN(arg))) {
             await props.commandCentre.current.cootCommand({
                 command: 'connect_updating_maps',
-                commandArgs: commandArgs,
+                commandArgs: connectMapsArgs,
+                returnType: 'status'
+            }, true)
+
+            await props.commandCentre.current.cootCommand({
+                command: 'sfcalc_genmaps_using_bulk_solvent',
+                commandArgs: sFcalcArgs,
                 returnType: 'status'
             }, true)
             
-            const connectedMapsEvent = new CustomEvent("connectedMaps", { detail: {
-                molecule: parseInt(moleculeSelectRef.current.value), map: parseInt(mapSelectRef.current.value)
-            } })
+            const connectedMapsEvent = new CustomEvent("connectedMaps")
             document.dispatchEvent(connectedMapsEvent)    
         }
         

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -430,7 +430,6 @@ export const MoorhenScoresToastPreferencesMenuItem = (props) => {
                         item: 'Moorhen Points'
                     }) }}
                     label="Show Moorhen points"/>
-
             </InputGroup>
         </>
     

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -390,6 +390,61 @@ export const MoorhenDefaultBondSmoothnessPreferencesMenuItem = (props) => {
 
 }
 
+export const MoorhenScoresToastPreferencesMenuItem = (props) => {
+   
+    const panelContent =
+        <>
+            <InputGroup style={{ padding:'0rem', width: '15rem'}}>
+                <Form.Check 
+                        type="switch"
+                        checked={props.showScoresToast}
+                        onChange={() => { props.setShowScoresToast(!props.showScoresToast) }}
+                        label="Show scores window"/>
+            </InputGroup>
+            <InputGroup style={{ padding:'0rem', width: '15rem'}}>
+                <Form.Check 
+                    type="switch"
+                    checked={props.defaultUpdatingScores.includes('Rfactor')}
+                    onChange={() => { props.setDefaultUpdatingScores({
+                        action: props.defaultUpdatingScores.includes('Rfactor') ? 'Remove' : 'Add',
+                        item: 'Rfactor'
+                    }) }}
+                    label="Show Rfactor"/>
+            </InputGroup>
+            <InputGroup style={{ padding:'0rem', width: '15rem'}}>
+                <Form.Check 
+                    type="switch"
+                    checked={props.defaultUpdatingScores.includes('Rfree')}
+                    onChange={() => { props.setDefaultUpdatingScores({
+                        action: props.defaultUpdatingScores.includes('Rfree') ? 'Remove' : 'Add',
+                        item: 'Rfree'
+                    }) }}
+                    label="Show Rfree"/>
+            </InputGroup>
+            <InputGroup style={{ padding:'0rem', width: '15rem'}}>
+                <Form.Check 
+                    type="switch"
+                    checked={props.defaultUpdatingScores.includes('Moorhen Points')}
+                    onChange={() => { props.setDefaultUpdatingScores({
+                        action: props.defaultUpdatingScores.includes('Moorhen Points') ? 'Remove' : 'Add',
+                        item: 'Moorhen Points'
+                    }) }}
+                    label="Show Moorhen points"/>
+
+            </InputGroup>
+
+        </>
+    
+    return <MoorhenMenuItem
+        popoverPlacement='right'
+        popoverContent={panelContent}
+        menuItemText={"Options for scores when updating maps"}
+        setPopoverIsShown={props.setPopoverIsShown}
+        showOkButton={false}
+    />
+
+}
+
 export const MoorhenMapSettingsMenuItem = (props) => {
     const mapSolid = props.mapSolid
     const panelContent =

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -432,7 +432,6 @@ export const MoorhenScoresToastPreferencesMenuItem = (props) => {
                     label="Show Moorhen points"/>
 
             </InputGroup>
-
         </>
     
     return <MoorhenMenuItem
@@ -968,7 +967,6 @@ export const MoorhenImportFSigFMenuItem = (props) => {
             const connectedMapsEvent = new CustomEvent("connectedMaps")
             document.dispatchEvent(connectedMapsEvent)    
         }
-        
     }
 
     const onCompleted = async () => {

--- a/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
@@ -135,9 +135,9 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
 
         let newCardList = []
 
-        pepflips.forEach(flip => {
+        pepflips.forEach((flip, index) => {
             newCardList.push(
-                <Card style={{margin: '0.5rem'}}>
+                <Card key={index} style={{margin: '0.5rem'}}>
                     <Card.Body>
                         <Row style={{display:'flex', justifyContent:'between'}}>
                             <Col style={{alignItems:'center', justifyContent:'left', display:'flex'}}>

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -3,7 +3,7 @@ import { NavDropdown, Form, InputGroup } from "react-bootstrap";
 import { MoorhenShortcutConfigModal } from "./MoorhenShortcutConfigModal"
 import { MenuItem } from "@mui/material";
 import { convertViewtoPx } from "../utils/MoorhenUtils";
-import { MoorhenDefaultBondSmoothnessPreferencesMenuItem } from './MoorhenMenuItem'
+import { MoorhenDefaultBondSmoothnessPreferencesMenuItem, MoorhenScoresToastPreferencesMenuItem } from './MoorhenMenuItem'
 import MoorhenSlider from './MoorhenSlider' 
 
 export const MoorhenPreferencesMenu = (props) => {
@@ -14,10 +14,11 @@ export const MoorhenPreferencesMenu = (props) => {
         setMouseSensitivity, drawCrosshairs, setDrawCrosshairs, drawMissingLoops,
         setDrawMissingLoops, mapLineWidth, setMapLineWidth, makeBackups, setMakeBackups,
         showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface,
-        defaultBondSmoothness, setDefaultBondSmoothness
+        defaultBondSmoothness, setDefaultBondSmoothness, showScoresToast, setShowScoresToast,
+        defaultUpdatingScores, setDefaultUpdatingScores
      } = props;
 
-     const [showModal, setShowModal] = useState(null);
+    const [showModal, setShowModal] = useState(null);
     const [popoverIsShown, setPopoverIsShown] = useState(false)
 
     return <NavDropdown
@@ -83,7 +84,7 @@ export const MoorhenPreferencesMenu = (props) => {
                             type="switch"
                             checked={showShortcutToast}
                             onChange={() => { setShowShortcutToast(!showShortcutToast) }}
-                            label="Show shortcut toast"/>
+                            label="Show shortcut popup"/>
                     </InputGroup>
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 
@@ -106,6 +107,13 @@ export const MoorhenPreferencesMenu = (props) => {
                             onChange={() => { setMakeBackups(!makeBackups) }}
                             label="Make molecule backups"/>
                     </InputGroup>
+                    <MoorhenScoresToastPreferencesMenuItem
+                        showScoresToast={showScoresToast}
+                        setShowScoresToast={setShowScoresToast}
+                        defaultUpdatingScores={defaultUpdatingScores}
+                        setDefaultUpdatingScores={setDefaultUpdatingScores}
+                        setPopoverIsShown={setPopoverIsShown}
+                    />
                     <MoorhenDefaultBondSmoothnessPreferencesMenuItem
                         defaultBondSmoothness={defaultBondSmoothness}
                         setDefaultBondSmoothness={setDefaultBondSmoothness}

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -57,12 +57,14 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
                 commandArgs: [],
             }, true)
             
-            setScoresDifference({
-                moorhenPoints: currentScores.data.result.result.rail_points_total - scores.moorhenPoints, 
-                rFactor: currentScores.data.result.result.r_factor - scores.rFactor,
-                rFree: currentScores.data.result.result.free_r_factor - scores.rFree,
-            })
-            
+            if (scores !== null) {
+                setScoresDifference({
+                    moorhenPoints: currentScores.data.result.result.rail_points_total - scores.moorhenPoints, 
+                    rFactor: currentScores.data.result.result.r_factor - scores.rFactor,
+                    rFree: currentScores.data.result.result.free_r_factor - scores.rFree,
+                })
+            }
+                        
             setScores({
                 moorhenPoints: currentScores.data.result.result.rail_points_total,
                 rFactor: currentScores.data.result.result.r_factor,
@@ -193,36 +195,48 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
 
     return  <>
-                {scores !== null && 
+                {scores !== null && props.preferences.showScoresToast &&
                     <ToastContainer style={{ zIndex: '0', marginTop: "5rem", marginLeft: '0.5rem', width:'15rem', textAlign:'left', alignItems: 'left'}} position='top-start' >
                         <Toast bg='light' onClose={() => {}} autohide={false} show={true}>
-                            <Toast.Body >
-                            <p style={{paddingLeft: '0.5rem', marginBottom:'0rem'}}>
+                            <Toast.Body>
+                            {props.preferences.defaultUpdatingScores.includes('Rfactor') && 
+                                <p style={{paddingLeft: '0.5rem', marginBottom:'0rem'}}>
                                     Clipper R-Factor {parseFloat(scores.rFactor).toFixed(3)}
                                 </p>
+                            }
+                            {props.preferences.defaultUpdatingScores.includes('Rfree') && 
                                 <p style={{paddingLeft: '0.5rem', marginBottom:'0rem'}}>
                                     Clipper R-Free {parseFloat(scores.rFree).toFixed(3)}
                                 </p>
+                            }
+                            {props.preferences.defaultUpdatingScores.includes('Moorhen Points') && 
                                 <p style={{paddingLeft: '0.5rem', marginBottom:'0rem'}}>
                                     Moorhen Points {scores.moorhenPoints}
                                 </p>
+                            }
                             </Toast.Body>
                         </Toast>
                     </ToastContainer>
                 }
-                {scoresDifference !== null &&
+                {scoresDifference !== null && props.preferences.showScoresToast &&
                     <ToastContainer style={{ zIndex: '0', marginTop: "5rem", marginLeft: '0.5rem', width:'15rem', textAlign:'left', alignItems: 'left'}} position='top-start' >
                         <Toast bg='light' onClose={() => setScoresDifference(null)} autohide={5000} show={scoresDifference !== null}>
-                            <Toast.Body >
-                            <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.rFactor < 0 ? 'green' : 'red'}}>
-                                    Clipper R-Factor {parseFloat(scores.rFactor).toFixed(3)} {`${scoresDifference.rFactor < 0 ? '' : '+'}${parseFloat(scoresDifference.rFactor).toFixed(3)}`}
-                                </p>
-                                <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.rFree < 0 ? 'green' : 'red'}}>
-                                    Clipper R-Free {parseFloat(scores.rFree).toFixed(3)} {`${scoresDifference.rFree < 0 ? '' : '+'}${parseFloat(scoresDifference.rFree).toFixed(3)}`}
-                                </p>
-                                <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.moorhenPoints < 0 ? 'red' : 'green'}}>
-                                    Moorhen Points {scores.moorhenPoints} {`${scoresDifference.moorhenPoints < 0 ? '' : '+'}${scoresDifference.moorhenPoints}`}
-                                </p>
+                            <Toast.Body>
+                                {props.preferences.defaultUpdatingScores.includes('Rfactor') && 
+                                    <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.rFactor < 0 ? 'green' : 'red'}}>
+                                        Clipper R-Factor {parseFloat(scores.rFactor).toFixed(3)} {`${scoresDifference.rFactor < 0 ? '' : '+'}${parseFloat(scoresDifference.rFactor).toFixed(3)}`}
+                                    </p>
+                                }
+                                {props.preferences.defaultUpdatingScores.includes('Rfree') && 
+                                    <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.rFree < 0 ? 'green' : 'red'}}>
+                                        Clipper R-Free {parseFloat(scores.rFree).toFixed(3)} {`${scoresDifference.rFree < 0 ? '' : '+'}${parseFloat(scoresDifference.rFree).toFixed(3)}`}
+                                    </p>
+                                }
+                                {props.preferences.defaultUpdatingScores.includes('Moorhen Points') && 
+                                    <p style={{paddingLeft: '0.5rem', marginBottom:'0rem', color: scoresDifference.moorhenPoints < 0 ? 'red' : 'green'}}>
+                                        Moorhen Points {scores.moorhenPoints} {`${scoresDifference.moorhenPoints < 0 ? '' : '+'}${scoresDifference.moorhenPoints}`}
+                                    </p>
+                                }
                             </Toast.Body>
                         </Toast>
                     </ToastContainer>

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -1,5 +1,17 @@
-import React, { createContext, useState, useEffect, useMemo } from "react";
+import React, { createContext, useState, useEffect, useMemo, useReducer } from "react";
 import localforage from 'localforage';
+
+const itemReducer = (oldList, change) => {
+    if (change.action === 'Add') {
+        return [...oldList, change.item]
+    }
+    else if (change.action === 'Remove') {
+        return oldList.filter(item => item !== change.item)
+    }
+    else if (change.action === 'Overwrite') {
+        return [...change.items]
+    }
+}
 
 const updateStoredPreferences = async (key, value) => {
     console.log(`Storing ${key}: ${value} preferences in local storage...`)
@@ -12,7 +24,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.8',
+        version: '0.0.11',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
@@ -26,6 +38,8 @@ const getDefaultValues = () => {
         showShortcutToast: true,
         defaultMapSurface: false,
         defaultBondSmoothness: 1,
+        showScoresToast: true,
+        defaultUpdatingScores: ['Rfree', 'Rfactor', 'Moorhen Points'],
         shortCuts: {
             "sphere_refine": {
                 modifiers: ["shiftKey"],
@@ -149,6 +163,8 @@ const PreferencesContextProvider = ({ children }) => {
     const [showShortcutToast, setShowShortcutToast] = useState(null)
     const [defaultMapSurface, setDefaultMapSurface] = useState(null)
     const [defaultBondSmoothness, setDefaultBondSmoothness] = useState(null)
+    const [showScoresToast, setShowScoresToast] = useState(null)
+    const [defaultUpdatingScores, setDefaultUpdatingScores] = useReducer(itemReducer, [])
 
     const restoreDefaults = (defaultValues)=> {
         updateStoredPreferences('version', defaultValues.version)
@@ -166,6 +182,8 @@ const PreferencesContextProvider = ({ children }) => {
         setShowShortcutToast(defaultValues.showShortcutToast)
         setDefaultMapSurface(defaultValues.defaultMapSurface)
         setDefaultBondSmoothness(defaultValues.defaultBondSmoothness)
+        setShowScoresToast(defaultValues.showScoresToast)
+        setDefaultUpdatingScores({action: 'Overwrite', items: defaultValues.defaultUpdatingScores})
     }
 
     /**
@@ -192,7 +210,9 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('makeBackups'),
                     localforage.getItem('showShortcutToast'),
                     localforage.getItem('defaultMapSurface'),
-                    localforage.getItem('defaultBondSmoothness')
+                    localforage.getItem('defaultBondSmoothness'),
+                    localforage.getItem('showScoresToast'),
+                    localforage.getItem('defaultUpdatingScores')
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -220,6 +240,8 @@ const PreferencesContextProvider = ({ children }) => {
                     setShowShortcutToast(response[12])
                     setDefaultMapSurface(response[13])
                     setDefaultBondSmoothness(response[14])
+                    setShowScoresToast(response[15])
+                    setDefaultUpdatingScores({action: 'Overwrite', items: response[16]})
                 }                
                 
             } catch (err) {
@@ -245,6 +267,24 @@ const PreferencesContextProvider = ({ children }) => {
        
         updateStoredPreferences('showShortcutToast', showShortcutToast);
     }, [showShortcutToast]);
+    
+    useMemo(() => {
+
+        if (showScoresToast === null) {
+            return
+        }
+       
+        updateStoredPreferences('showScoresToast', showScoresToast);
+    }, [showScoresToast]);
+    
+    useMemo(() => {
+
+        if (defaultUpdatingScores === null || defaultUpdatingScores.length === 0) {
+            return
+        }
+       
+        updateStoredPreferences('defaultUpdatingScores', defaultUpdatingScores);
+    }, [defaultUpdatingScores]);
     
     useMemo(() => {
 
@@ -369,7 +409,8 @@ const PreferencesContextProvider = ({ children }) => {
         refineAfterMod, setRefineAfterMod, mouseSensitivity, setMouseSensitivity, drawCrosshairs, 
         setDrawCrosshairs, drawMissingLoops, setDrawMissingLoops, mapLineWidth, setMapLineWidth,
         makeBackups, setMakeBackups, showShortcutToast, setShowShortcutToast, defaultMapSurface,
-        setDefaultMapSurface, defaultBondSmoothness, setDefaultBondSmoothness
+        setDefaultMapSurface, defaultBondSmoothness, setDefaultBondSmoothness, showScoresToast, 
+        setShowScoresToast, defaultUpdatingScores, setDefaultUpdatingScores
     }
 
     return (

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -24,7 +24,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.11',
+        version: '0.0.9',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,


### PR DESCRIPTION
This update includes:
- Control for the scores that are shown after updating maps has been added to preferences.
- `sfcalc_genmaps_using_bulk_solvent` is used when connecting maps, which means scores are correct even before the first modification.