### PR TITLE
Use recursion to skip map re-contours while busy

### DIFF
--- a/baby-gru/src/utils/MoorhenMap.js
+++ b/baby-gru/src/utils/MoorhenMap.js
@@ -176,9 +176,8 @@ MoorhenMap.prototype.makeWebMGUnlive = function (glRef) {
     glRef.current.drawScene()
 }
 
-MoorhenMap.prototype.makeCootLive = function (glRef, mapRadius) {
+MoorhenMap.prototype.makeCootLive = function (glRef) {
     const $this = this
-    $this.mapRadius = mapRadius
     $this.cootContour = true
     $this.doCootContour(glRef,
         -glRef.current.origin[0],
@@ -236,7 +235,6 @@ MoorhenMap.prototype.clearBuffersOfStyle = function (glRef, style) {
 MoorhenMap.prototype.doCootContour = function (glRef, x, y, z, radius, contourLevel) {
 
     const $this = this
-    $this.mapRadius = radius
 
     let returnType
     if (this.litLines) {


### PR DESCRIPTION
This implements the intended correct behaviour of the map sliders. Now, the map sliders will skip updates while busy. Then, if there is a pending update, it will be done after the current update is completed. This way playing with the contour level and radius sliders won't lock the app for so long.