### PR TITLE
Only redraw molecule if not busy

### DIFF
--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -136,7 +136,7 @@ export const MoorhenMapCard = (props) => {
                 </Fragment>
     }
 
-    const reContourIfDirty = () => {
+    const doContourIfDirty = () => {
         if (isDirty.current) {
             busyContouring.current = true
             isDirty.current = false
@@ -146,7 +146,7 @@ export const MoorhenMapCard = (props) => {
                 props.map.contourLevel)
                 .then(result => {
                     busyContouring.current = false
-                    reContourIfDirty()
+                    doContourIfDirty()
                 })
         }
     }
@@ -160,7 +160,7 @@ export const MoorhenMapCard = (props) => {
             if (busyContouring.current) {
                 console.log('Skipping map update because already busy ')
             } else {
-                reContourIfDirty()
+                doContourIfDirty()
             }
         }
     }, [mapContourLevel, mapRadius])
@@ -216,7 +216,7 @@ export const MoorhenMapCard = (props) => {
         props.map.mapRadius = mapRadius
         isDirty.current = true
         if (props.map.cootContour && !busyContouring.current) {
-            reContourIfDirty()
+            doContourIfDirty()
         } else {
             console.log('Skipping map re-contour because already busy ')
         }

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { Card, Form, Row, Col, Accordion } from "react-bootstrap";
 import { doDownload, sequenceIsValid } from '../utils/MoorhenUtils';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
@@ -15,10 +15,23 @@ export const MoorhenMoleculeCard = (props) => {
     const [bondWidth, setBondWidth] = useState(0.1)
     const [atomRadiusBondRatio, setAtomRadiusBondRatio] = useState(1.5)
     const [bondSmoothness, setBondSmoothness] = useState(props.defaultBondSmoothness)
+    const busyRedrawing = useRef(false)
+    const isDirty = useRef(false)
 
     const bondSettingsProps = {
         bondWidth, setBondWidth, atomRadiusBondRatio,
         setAtomRadiusBondRatio, bondSmoothness, setBondSmoothness
+    }
+
+    const redrawIfDirty = async () => {
+        if (isDirty.current) {
+            busyRedrawing.current = true
+            isDirty.current = false
+            props.molecule.setAtomsDirty(true)
+            await props.molecule.redraw(props.glRef)
+            busyRedrawing.current = false
+            redrawIfDirty()
+        }
     }
 
     useEffect(() => {
@@ -56,8 +69,12 @@ export const MoorhenMoleculeCard = (props) => {
 
         if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.smoothness !== bondSmoothness) {
             props.molecule.cootBondsOptions.smoothness = bondSmoothness
-            props.molecule.setAtomsDirty(true)
-            props.molecule.redraw(props.glRef)
+            isDirty.current = true
+            if (!busyRedrawing.current) {
+                redrawIfDirty()
+            } else {
+                console.log('Skipping molecule re-draw because already busy ')
+            }
         } else {
             props.molecule.cootBondsOptions.smoothness = bondSmoothness
         }
@@ -71,8 +88,14 @@ export const MoorhenMoleculeCard = (props) => {
 
         if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.width !== bondWidth) {
             props.molecule.cootBondsOptions.width = bondWidth
-            props.molecule.setAtomsDirty(true)
-            props.molecule.redraw(props.glRef)
+            isDirty.current = true
+            if (!busyRedrawing.current) {
+                console.log('HAHAHAHAHHA')
+                console.log(busyRedrawing.current)
+                redrawIfDirty()
+            } else {
+                console.log('Skipping molecule re-draw because already busy ')
+            }
         } else {
             props.molecule.cootBondsOptions.width = bondWidth
         }
@@ -86,8 +109,12 @@ export const MoorhenMoleculeCard = (props) => {
 
         if (isVisible && showState['CBs'] && props.molecule.cootBondsOptions.atomRadiusBondRatio !== atomRadiusBondRatio) {
             props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
-            props.molecule.setAtomsDirty(true)
-            props.molecule.redraw(props.glRef)
+            isDirty.current = true
+            if (!busyRedrawing.current) {
+                redrawIfDirty()
+            } else {
+                console.log('Skipping molecule re-draw because already busy ')
+            }
         } else {
             props.molecule.cootBondsOptions.atomRadiusBondRatio = atomRadiusBondRatio
         }


### PR DESCRIPTION
Similar to #144 but with bond settings. This fixes a bug where playing with the bond smoothness and bond radius sliders would break the app if too many redraws are requested. Now only the most recent molecule redraw is requested (one at a time).