### PR TITLE
Update UI for map settings

### DIFF
--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -22,7 +22,7 @@ export const MoorhenMapCard = (props) => {
     const isDirty = useRef(false)
 
     const mapSettingsProps = {
-        mapOpacity, setMapOpacity, mapSolid, setMapSolid
+        mapOpacity, setMapOpacity, mapSolid, setMapSolid, mapLitLines, setMapLitLines
     }
 
     const handleDownload = async () => {
@@ -43,16 +43,6 @@ export const MoorhenMapCard = (props) => {
         props.setCurrentDropdownMolNo(-1)
     }
 
-    const handleLitLines = () => {
-        setMapLitLines(!mapLitLines)
-        props.setCurrentDropdownMolNo(-1)
-    }
-
-    const handleSolid = () => {
-        setMapSolid(!mapSolid)
-        props.setCurrentDropdownMolNo(-1)
-    }
-
     const actionButtons = {
         1: {
             label: cootContour ? "Hide map" : "Show map", 
@@ -69,18 +59,13 @@ export const MoorhenMapCard = (props) => {
                                       </Button> )},
         },
         3: {
-            label: mapLitLines ? "Deactivate lit lines" : "Activate lit lines",
-            compressed: () => {return (<MenuItem key='activate-deactivate-lit-lines' variant="success" disabled={!cootContour}  onClick={handleLitLines}>{mapLitLines ? "Deactivate lit lines" : "Activate lit lines"}</MenuItem>)},
-            expanded: null
-        },
-        4: {
             label: 'Rename map',
             compressed: () => {return (<MoorhenRenameDisplayObjectMenuItem key='rename-map' setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.map} />)},
             expanded: null
         },
-        5: {
+        4: {
             label: "Map draw settings",
-            compressed: () => {return (<MoorhenMapSettingsMenuItem key={5} disabled={!cootContour} setPopoverIsShown={setPopoverIsShown} map={props.map} {...mapSettingsProps} />)},
+            compressed: () => {return (<MoorhenMapSettingsMenuItem key='map-draw-settings' disabled={!cootContour} setPopoverIsShown={setPopoverIsShown} map={props.map} {...mapSettingsProps} />)},
             expanded: null
         }
     }

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -444,10 +444,20 @@ export const MoorhenScoresToastPreferencesMenuItem = (props) => {
 }
 
 export const MoorhenMapSettingsMenuItem = (props) => {
-    const mapSolid = props.mapSolid
     const panelContent =
         <>
-            <MenuItem key='solid-or-chickenwire' variant="success" onClick={() => {props.setMapSolid(!mapSolid) }}>Draw as {mapSolid ? "Chickenwire" : "Solid"}</MenuItem>
+            <Form.Check 
+                type="switch"
+                checked={props.mapSolid}
+                onChange={() => {props.setMapSolid(!props.mapSolid)}}
+                label="Draw as a surface"/>
+            {!props.mapSolid &&
+                <Form.Check 
+                    type="switch"
+                    checked={props.mapLitLines}
+                    onChange={() => {props.setMapLitLines(!props.mapLitLines)}}
+                    label="Activate lit lines"/>
+            }
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenMapOpacitySlider">
                 <MoorhenSlider minVal={0.0} maxVal={1.0} logScale={false} sliderTitle="Opacity" intialValue={props.mapOpacity} externalValue={props.mapOpacity} setExternalValue={props.setMapOpacity} />
             </Form.Group>
@@ -456,6 +466,7 @@ export const MoorhenMapSettingsMenuItem = (props) => {
         popoverPlacement='left'
         popoverContent={panelContent}
         menuItemText={"Draw settings"}
+        showOkButton={false}
         setPopoverIsShown={props.setPopoverIsShown}
     />
  

--- a/baby-gru/src/utils/MoorhenMap.js
+++ b/baby-gru/src/utils/MoorhenMap.js
@@ -237,10 +237,10 @@ MoorhenMap.prototype.doCootContour = function (glRef, x, y, z, radius, contourLe
     const $this = this
 
     let returnType
-    if (this.litLines) {
-        returnType = "lit_lines_mesh"
-    } else if(this.solid){
+    if(this.solid) {
         returnType = "mesh"
+    } else if (this.litLines) {
+        returnType = "lit_lines_mesh"
     } else {
         returnType = "lines_mesh"
     }


### PR DESCRIPTION
This moves "activate lit lines" into the map display settings menu. Code to handle the combination of map surface + lit lines has been added (previously this would show a chickenwire map).