### PR TITLE
Re-think advanced display options UI

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.js
+++ b/baby-gru/public/baby-gru/CootWorker.js
@@ -243,6 +243,17 @@ const simpleMeshToMeshData = (simpleMesh) => {
     };
 }
 
+const colourRulesToJSArray = (colourRulesArray) => {
+    let returnResult = []
+    const colourRulesSize = colourRulesArray.size()
+    for (let i = 0; i < colourRulesSize; i++) {
+        const rule = colourRulesArray.get(i)
+        returnResult.push(rule)
+    }
+    colourRulesArray.delete()
+    return returnResult;
+}
+
 const floatArrayToJSArray = (floatArray) => {
     let returnResult = []
     const floatArraySize = floatArray.size()
@@ -682,6 +693,9 @@ onmessage = function (e) {
             switch (returnType) {
                 case 'instanced_mesh_perm':
                     returnResult = instancedMeshToMeshData(cootResult, true)
+                    break;
+                case 'colour_rules':
+                    returnResult = colourRulesToJSArray(cootResult)
                     break;
                 case 'instanced_mesh':
                     returnResult = instancedMeshToMeshData(cootResult)

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -73,6 +73,7 @@ export const MoorhenContainer = (props) => {
     const [showToast, setShowToast] = useState(false)
     const preferences = useContext(PreferencesContext);
     const [toastContent, setToastContent] = useState("")
+    const [showAdvancedDisplayOptions, setShowAdvancedDisplayOptions] = useState(false)
 
     const sideBarWidth = convertViewtoPx(30, windowWidth)
     const innerWindowMarginHeight = convertRemToPx(2.1)
@@ -293,7 +294,7 @@ export const MoorhenContainer = (props) => {
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, sideBarWidth,
         navBarRef, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, toastContent, setToastContent, 
         showToast, setShowToast, windowWidth, windowHeight, showSideBar, innerWindowMarginWidth, toolAccordionBodyHeight,
-        urlPrefix: props.urlPrefix, ...preferences
+        urlPrefix: props.urlPrefix, showAdvancedDisplayOptions, setShowAdvancedDisplayOptions, ...preferences
     }
 
     const accordionToolsItemProps = {
@@ -361,6 +362,10 @@ export const MoorhenContainer = (props) => {
                             onKeyPress={onKeyPress}
                             hoveredAtom={hoveredAtom}
                             preferences={preferences}
+                            setShowAdvancedDisplayOptions={setShowAdvancedDisplayOptions}
+                            showAdvancedDisplayOptions={showAdvancedDisplayOptions}
+                            windowHeight={windowHeight}
+                            windowWidth={windowWidth}
                         />
                     </div>
                     <div id='button-bar-baby-gru'

--- a/baby-gru/src/components/MoorhenViewMenu.js
+++ b/baby-gru/src/components/MoorhenViewMenu.js
@@ -2,12 +2,9 @@ import { NavDropdown } from "react-bootstrap";
 import { useState } from "react";
 import { MenuItem } from "@mui/material";
 import { MoorhenBackgroundColorMenuItem, MoorhenClipFogMenuItem } from "./MoorhenMenuItem";
-import { MoorhenAdvancedDisplayOptions } from "./MoorhenAdvancedDisplayOptions"
-
 
 export const MoorhenViewMenu = (props) => {
     const [popoverIsShown, setPopoverIsShown] = useState(false)
-    const [showAdvancedDisplayOptions, setShowAdvancedDisplayOptions] = useState(false)
     const menuItemProps = {setPopoverIsShown, ...props}
 
     return <>
@@ -21,11 +18,13 @@ export const MoorhenViewMenu = (props) => {
                 <MoorhenBackgroundColorMenuItem {...menuItemProps} />
                 <hr></hr>
                 <MoorhenClipFogMenuItem {...menuItemProps} />
-                <MenuItem onClick={() => setShowAdvancedDisplayOptions(true)}>
+                <MenuItem onClick={() => {
+                    props.setShowAdvancedDisplayOptions(true)
+                    document.body.click()
+                }}>
                     Advanced Display Options
                 </MenuItem>
             </NavDropdown >
-            <MoorhenAdvancedDisplayOptions showAdvancedDisplayOptions={showAdvancedDisplayOptions} setShowAdvancedDisplayOptions={setShowAdvancedDisplayOptions} {...props}/>
         </>
     }
 

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -968,7 +968,8 @@ MoorhenMolecule.prototype.redraw = function (glRef) {
             },
             Promise.resolve()
         )
-    }).catch(_ => {
+    }).catch(err => {
+        console.log(err)
         console.log('Error updating atoms when redrawing')
     })
 }


### PR DESCRIPTION
This is a big update to the way the advanced display options are shown in the UI. The idea was to make them more compact so that they use less space. These options have been moved to the same toast container where the scores are shown after connecting maps. This new modal stays transparent so that the user can see the model, and only when hovered it will increase opacity. Additionally, the colour rules currently used for a given molecule are now listed.