### PR TITLE
Add jump to next/prev residue to shortcuts and other updates

### DIFF
--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -18,12 +18,13 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     let modifiers = []
     let eventModifiersCodes = []
 
-    if (event.shiftKey) modifiers.push("<Shift>")
-    if (event.ctrlKey) modifiers.push("<Ctrl>")
-    if (event.metaKey) modifiers.push("<Meta>")
-    if (event.altKey) modifiers.push("<Alt>")
+    if (event.shiftKey) modifiers.push("<Shift>") && eventModifiersCodes.push('shiftKey')
+    if (event.ctrlKey) modifiers.push("<Ctrl>") && eventModifiersCodes.push('ctrlKey')
+    if (event.metaKey) modifiers.push("<Meta>") && eventModifiersCodes.push('metaKey')
+    if (event.altKey) modifiers.push("<Alt>") && eventModifiersCodes.push('altKey')
+    if (event.key === " ") modifiers.push("<Space>")
 
-    const { setShowToast, setToastContent, hoveredAtom, setHoveredAtom, commandCentre, activeMap, glRef } = collectedProps;
+    const { setShowToast, setToastContent, hoveredAtom, setHoveredAtom, commandCentre, activeMap, glRef, molecules } = collectedProps;
 
     if (collectedProps.showShortcutToast) {
         setToastContent(<h3>{`${modifiers.join("-")} ${event.key} pushed`}</h3>)
@@ -345,6 +346,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
                 if (shortCuts[key].modifiers.includes('ctrlKey')) modifiers.push("<Ctrl>")
                 if (shortCuts[key].modifiers.includes('metaKey')) modifiers.push("<Meta>")
                 if (shortCuts[key].modifiers.includes('altKey')) modifiers.push("<Alt>")
+                if (shortCuts[key].keyPress === " ") modifiers.push("<Space>")
                 return <ListItem>{`${modifiers.join("-")} ${shortCuts[key].keyPress} ${shortCuts[key].label}`}</ListItem>
             })}
         </List></h4>)

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -373,10 +373,9 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
             }
 
             const [moleculeName, modelNumber, resNum, atomName] = residueCid.split('/')
-            //if (!chainId || !resInfo) {
-            //    return
-            //}
-            const chainId = 'A'
+            
+            // ASSUMING FIRST CHAIN UNTIL RESIDUE CID INCLUDES BACK CHAIN NAME
+            const chainId = selectedMolecule.sequences[0].chain
 
             const selectedSequence = selectedMolecule.sequences.find(sequence => sequence.chain === chainId)
             if (selectedSequence === 'undefined') {

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -16,6 +16,7 @@ const apresEdit = (molecule, glRef, setHoveredAtom) => {
 export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     console.log(event)
     let modifiers = []
+    let eventModifiersCodes = []
 
     if (event.shiftKey) modifiers.push("<Shift>")
     if (event.ctrlKey) modifiers.push("<Ctrl>")
@@ -32,7 +33,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     let action = null;
 
     for (const key of Object.keys(shortCuts)) {
-        if (shortCuts[key].keyPress === event.key.toLowerCase() && shortCuts[key].modifiers.every(modifier => event[modifier])) {
+        if (shortCuts[key].keyPress === event.key.toLowerCase() && shortCuts[key].modifiers.every(modifier => event[modifier]) && eventModifiersCodes.every(modifier => shortCuts[key].modifiers.includes(modifier))) {
             action = key
             break
         }

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -355,18 +355,7 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     }
 
     else if (action === 'jump_next_residue' || action === 'jump_previous_residue') {
-        const visibleMolecules = molecules.filter(molecule => {
-            if (!molecule.isVisible) {
-                return false
-            } 
-            const styles = Object.keys(molecule.displayObjects).filter(key => !['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
-            const displayBuffers = styles.map(style => molecule.displayObjects[style])
-            const visibleDisplayBuffers = displayBuffers.filter(displayBuffer => displayBuffer.some(buffer => buffer.visible))
-            if (visibleDisplayBuffers.length === 0) {
-                return false
-            }
-            return true
-        })
+        const visibleMolecules = molecules.filter(molecule => molecule.isVisible && molecule.hasVisibleBuffers())
         if (visibleMolecules.length === 0) {
             return
         }

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -355,7 +355,18 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     }
 
     else if (action === 'jump_next_residue' || action === 'jump_previous_residue') {
-        const visibleMolecules = molecules.filter(molecule => molecule.isVisible)
+        const visibleMolecules = molecules.filter(molecule => {
+            if (!molecule.isVisible) {
+                return false
+            } 
+            const styles = Object.keys(molecule.displayObjects).filter(key => !['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
+            const displayBuffers = styles.map(style => molecule.displayObjects[style])
+            const visibleDisplayBuffers = displayBuffers.filter(displayBuffer => displayBuffer.some(buffer => buffer.visible))
+            if (visibleDisplayBuffers.length === 0) {
+                return false
+            }
+            return true
+        })
         if (visibleMolecules.length === 0) {
             return
         }

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -386,7 +386,7 @@ export const MoorhenMoleculeCard = (props) => {
                                 <div>
                                     <FormGroup style={{ margin: "0px", padding: "0px" }} row>
                                         {Object.keys(props.molecule.displayObjects)
-                                            .filter(key => !['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].includes(key))
+                                            .filter(key => !['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
                                             .map(key => getCheckBox(key))}
                                     </FormGroup>
                                 </div>

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -213,7 +213,11 @@ export const MoorhenMoleculeCard = (props) => {
 
     }, [surfaceGridScale]);
 
-
+    useEffect(() => {
+        if (isVisible !== props.molecule.isVisible) {
+            props.molecule.isVisible = isVisible
+        }
+    }, [isVisible]);
 
     useEffect(() => {
         Object.keys(props.molecule.displayObjects).forEach(key => {

--- a/baby-gru/src/components/MoorhenShortcutConfigModal.js
+++ b/baby-gru/src/components/MoorhenShortcutConfigModal.js
@@ -48,7 +48,8 @@ export const MoorhenShortcutConfigModal = (props) => {
         if (evt.ctrlKey) modifiers.push("<Ctrl>")
         if (evt.metaKey) modifiers.push("<Meta>")
         if (evt.altKey) modifiers.push("<Alt>")
-    
+        if (evt.key === " ") modifiers.push("<Space>")
+
         setShortCutMessage(`${modifiers.join("-")} ${evt.key.toLowerCase()}`)
     }
 
@@ -77,6 +78,7 @@ export const MoorhenShortcutConfigModal = (props) => {
                             if (stagedShortCuts[key].modifiers.includes('ctrlKey')) modifiers.push("<Ctrl>")
                             if (stagedShortCuts[key].modifiers.includes('metaKey')) modifiers.push("<Meta>")
                             if (stagedShortCuts[key].modifiers.includes('altKey')) modifiers.push("<Alt>")                
+                            if (stagedShortCuts[key].keyPress === " ") modifiers.push("<Space>")
                             return <Card key={key} style={{margin:'0.5rem'}}>
                                         <Card.Body style={{padding:'0.5rem'}}>
                                             <Row className="align-items-center">

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -1238,3 +1238,10 @@ MoorhenMolecule.prototype.gemmiAtomsForCid = async function (cid) {
 
     return Promise.resolve(result)
 }
+
+MoorhenMolecule.prototype.hasVisibleBuffers = function (excludeBuffers = ['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface']) {
+    const styles = Object.keys(this.displayObjects).filter(key => !excludeBuffers.some(style => key.includes(style)))
+    const displayBuffers = styles.map(style => this.displayObjects[style])
+    const visibleDisplayBuffers = displayBuffers.filter(displayBuffer => displayBuffer.some(buffer => buffer.visible))
+    return visibleDisplayBuffers.length !== 0
+}

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -16,6 +16,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
     this.enerLib = new EnerLib()
     this.HBondsAssigned = false
     this.atomsDirty = true
+    this.isVisible = true
     this.name = "unnamed"
     this.molNo = null
     this.gemmiStructure = null

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -24,7 +24,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.10',
+        version: '0.0.11',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
@@ -142,7 +142,16 @@ const getDefaultValues = () => {
                 keyPress: "control",
                 label: "Set map contour on scroll"
             },
-
+            "jump_next_residue": {
+                modifiers: [],
+                keyPress: " ",
+                label: "Jump to the next residue"
+            },
+            "jump_previous_residue": {
+                modifiers: ["shiftKey"],
+                keyPress: " ",
+                label: "Jump to the previous residue"
+            },
         }
     }
 }

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -448,5 +448,6 @@ export const getTooltipShortcutLabel = (shortCut) => {
     if (shortCut.modifiers.includes('ctrlKey')) modifiers.push("<Ctrl>")
     if (shortCut.modifiers.includes('metaKey')) modifiers.push("<Meta>")
     if (shortCut.modifiers.includes('altKey')) modifiers.push("<Alt>")
+    if (shortCut.keyPress === " ") modifiers.push("<Space>")
     return `<${modifiers.join(" ")} ${shortCut.keyPress.toUpperCase()}>`
 }

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -340,6 +340,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<>()
+    .function("get_active_atom",&molecules_container_t::get_active_atom)
     .function("is_a_difference_map",&molecules_container_t::is_a_difference_map)
     .function("add_hydrogen_atoms",&molecules_container_t::add_hydrogen_atoms)
     .function("delete_hydrogen_atoms",&molecules_container_t::delete_hydrogen_atoms)
@@ -623,6 +624,10 @@ EMSCRIPTEN_BINDINGS(my_module) {
     value_object<std::pair<std::string,std::string>>("string_string_pair")
         .field("first",&std::pair<std::string, std::string>::first)
         .field("second",&std::pair<std::string, std::string>::second)
+    ;
+    value_object<std::pair<int,std::string>>("int_string_pair")
+        .field("first",&std::pair<int,std::string>::first)
+        .field("second",&std::pair<int,std::string>::second)
     ;
     value_object<std::pair<unsigned int,int>>("uint_int_pair")
         .field("first",&std::pair<unsigned int,int>::first)


### PR DESCRIPTION
This update includes:
- Added `get_active_atom` to moorhen wrappers and wrapped its return type `int_string_pair` using `value_object`.
- Jump to next/previous residue has been added to shortcuts. By default they are binded to `Space` and `Shift+Space`. At the moment this always assumes the residue corresponds with the first chain (API function does not return chain name in the CID yet).
- The way shortcuts involving a "Space" are displayed in the UI has improved (now it shows `<Space>` instead of just an empty space).
- Contact dots and chemical features are filtered out from the checkboxes in the display options.
- A new `isVisible` attribute was added to `MoorhenMolecule` which is synced with its molecule card.
- A new `hasVisibleBuffers` was added to `MoorhenMolecule` and can be used to determine whether there are visible buffers for the given molecule.
- Keyboard accelerators are more accurate when assigning a given shortcut an action. Now this only occurs if all the modifiers in the event are also assigned to the shortcut. This prevents events being triggered if their modifier was not pressed. This also prevents shortcuts being assigned the wrong action when the only difference is a modifier.
