### PR TITLE
Hide score toast if connected molecule or map is deleted

### DIFF
--- a/baby-gru/cloud/index.js
+++ b/baby-gru/cloud/index.js
@@ -68,7 +68,7 @@ class MoorhenWrapper {
               await newMolecule.loadToCootFromURL(inputFile, molName)
               await newMolecule.fetchIfDirtyAndDraw('CBs', this.controls.glRef)
               this.controls.changeMolecules({ action: "Add", item: newMolecule })
-              newMolecule.centreOn(this.controls.glRef)
+              newMolecule.centreOn(this.controls.glRef, null, false)
               return resolve(newMolecule)
           } catch (err) {
               console.log(`Cannot fetch molecule from ${inputFile}`)

--- a/baby-gru/src/WebGLgComponents/mgWebGL.js
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.js
@@ -3540,7 +3540,6 @@ class MGWebGL extends Component {
     }
 
     centreOn(idx) {
-        console.log("centreOn!!!!")
         var self = this;
         if (self.displayBuffers[idx].atoms.length > 0) {
             var xtot = 0;

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -36,7 +36,7 @@ export const MoorhenFileMenu = (props) => {
         await Promise.all(drawPromises)
 
         changeMolecules({ action: "AddList", items: newMolecules })
-        newMolecules.at(-1).centreOn(glRef)
+        newMolecules.at(-1).centreOn(glRef, null, false)
     }
 
     const readPdbFile = (file) => {
@@ -92,7 +92,7 @@ export const MoorhenFileMenu = (props) => {
                 await newMolecule.loadToCootFromURL(url, molName)
                 await newMolecule.fetchIfDirtyAndDraw('CBs', glRef)
                 changeMolecules({ action: "Add", item: newMolecule })
-                newMolecule.centreOn(glRef)
+                newMolecule.centreOn(glRef, null, false)
             } catch {
                 console.log(`Cannot fetch molecule from ${url}`)
                 setIsValidPdbId(false)

--- a/baby-gru/src/components/MoorhenHistoryMenu.js
+++ b/baby-gru/src/components/MoorhenHistoryMenu.js
@@ -82,7 +82,7 @@ export const MoorhenHistoryMenu = (props) => {
                         const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
                         newMolecule.molNo = reply.data.result.result
                         newMolecule.name = nextCommand.commandArgs[1]
-                        newMolecule.centreOn(props.glRef)
+                        newMolecule.centreOn(props.glRef, null, false)
                         props.changeMolecules({ action: "Add", item: newMolecule })
                         return newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
                     }

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1104,7 +1104,12 @@ export const MoorhenImportFSigFMenuItem = (props) => {
                 returnType: 'status'
             }, true)
 
-            const connectedMapsEvent = new CustomEvent("connectedMaps")
+            const connectedMapsEvent = new CustomEvent("connectMaps", {
+                "detail": {
+                    molecule: connectMapsArgs[0],
+                    maps: [...new Set(connectMapsArgs.slice(1))]
+                }
+            })
             document.dispatchEvent(connectedMapsEvent)
         }
     }

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -120,7 +120,7 @@ export const MoorhenLoadTutorialDataMenuItem = (props) => {
                 props.changeMolecules({ action: "Add", item: newMolecule })
                 Promise.resolve(newMolecule)
             }).then(_ => {
-                newMolecule.centreOn(props.glRef)
+                newMolecule.centreOn(props.glRef, null, false)
             }).then(_ => {
                 return newMap.loadToCootFromMtzURL(`${props.urlPrefix}/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`, `moorhen-tutorial-${tutorialNumber}`,
                     {

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -109,7 +109,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             } else {
                 setScoreToastContents(newToastContents)
             }
-                        
+
             scores.current = {
                 moorhenPoints: currentScores.data.result.result.rail_points_total,
                 rFactor: currentScores.data.result.result.r_factor,
@@ -119,6 +119,12 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
     }, [props.commandCentre, connectedMaps, scores, props.preferences.defaultUpdatingScores])
 
+    const handleDisconnectMaps = () => {
+        scores.current = {}
+        setConnectedMaps(false)
+        setScoreToastContents(null)
+    }
+    
     const handleConnectedMaps = useCallback(async () => {
         
         const currentScores = await props.commandCentre.current.cootCommand({
@@ -188,6 +194,14 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
         };
 
     }, [handleConnectedMaps]);
+
+    useEffect(() => {
+        document.addEventListener("disconnectMaps", handleDisconnectMaps);
+        return () => {
+            document.removeEventListener("disconnectMaps", handleDisconnectMaps);
+        }
+
+    }, [handleDisconnectMaps]);
 
     useEffect(() => {
         document.addEventListener("mapUpdate", handleScoreUpdates);
@@ -262,12 +276,6 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             setMapLineWidth(props.preferences.mapLineWidth)
         }
     }, [props.preferences])
-
-    useEffect(() => {
-        props.molecules.forEach(molecule => {
-            //molecule.fetchIfDirtyAndDraw('bonds', glRef)
-        })
-    }, [props.molecules, props.molecules.length])
 
     useEffect(() => {
         props.maps.forEach(map => {

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -8,7 +8,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     const scores = useRef({})
     const windowResizedBinding = createRef(null)
     const [mapLineWidth, setMapLineWidth] = useState(1.0)
-    const [connectedMaps, setConnectedMaps] = useState(false)
+    const [connectedMolNo, setConnectedMolNo] = useState(null)
     const [scoresToastContents, setScoreToastContents] = useState(null)
 
     const setClipFogByZoom = () => {
@@ -51,7 +51,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     }, [props.hoveredAtom, glRef])
 
     const handleScoreUpdates = useCallback(async (e) => {
-        if (e.detail?.modifiedMolecule !== null && connectedMaps) {
+        if (e.detail?.modifiedMolecule !== null && connectedMolNo) {
             
             const currentScores = await props.commandCentre.current.cootCommand({
                 returnType: "r_factor_stats",
@@ -117,15 +117,15 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             }
         } 
 
-    }, [props.commandCentre, connectedMaps, scores, props.preferences.defaultUpdatingScores])
+    }, [props.commandCentre, connectedMolNo, scores, props.preferences.defaultUpdatingScores])
 
     const handleDisconnectMaps = () => {
         scores.current = {}
-        setConnectedMaps(false)
+        setConnectedMolNo(null)
         setScoreToastContents(null)
     }
     
-    const handleConnectedMaps = useCallback(async () => {
+    const handleConnectMaps = useCallback(async (evt) => {
         
         const currentScores = await props.commandCentre.current.cootCommand({
             returnType: "r_factor_stats",
@@ -159,11 +159,11 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             rFree: currentScores.data.result.result.free_r_factor
         }
 
-        setConnectedMaps(true)
+        setConnectedMolNo(evt.detail)
     }, [props.commandCentre, props.preferences.defaultUpdatingScores])
 
     useEffect(() => {
-        if (scores.current !== null && props.preferences.defaultUpdatingScores !== null && props.preferences.showScoresToast && connectedMaps) {
+        if (scores.current !== null && props.preferences.defaultUpdatingScores !== null && props.preferences.showScoresToast && connectedMolNo) {
             setScoreToastContents(
                 <Toast.Body>
                     {props.preferences.defaultUpdatingScores.includes('Rfactor') && 
@@ -188,20 +188,12 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     }, [props.preferences.defaultUpdatingScores, props.preferences.showScoresToast]);
 
     useEffect(() => {
-        document.addEventListener("connectedMaps", handleConnectedMaps);
+        document.addEventListener("connectMaps", handleConnectMaps);
         return () => {
-            document.removeEventListener("connectedMaps", handleConnectedMaps);
+            document.removeEventListener("connectMaps", handleConnectMaps);
         };
 
-    }, [handleConnectedMaps]);
-
-    useEffect(() => {
-        document.addEventListener("disconnectMaps", handleDisconnectMaps);
-        return () => {
-            document.removeEventListener("disconnectMaps", handleDisconnectMaps);
-        }
-
-    }, [handleDisconnectMaps]);
+    }, [handleConnectMaps]);
 
     useEffect(() => {
         document.addEventListener("mapUpdate", handleScoreUpdates);
@@ -278,6 +270,19 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     }, [props.preferences])
 
     useEffect(() => {
+        if (connectedMolNo && props.molecules.lenght === 0){
+            handleDisconnectMaps()
+        } else if (connectedMolNo && !props.molecules.includes(connectedMolNo.molecule)){
+            handleDisconnectMaps()
+        }
+    }, [props.molecules])
+
+    useEffect(() => {
+        if (connectedMolNo && props.maps.lenght === 0){
+            handleDisconnectMaps()
+        } else if (connectedMolNo && !connectedMolNo.maps.every(mapMolNo => props.maps.includes(mapMolNo))){
+            handleDisconnectMaps()
+        }
         props.maps.forEach(map => {
             console.log('in map changed useEffect')
             if (map.webMGContour) {

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -314,7 +314,7 @@ MoorhenMolecule.prototype.fetchIfDirtyAndDraw = async function (style, glRef) {
     })
 }
 
-MoorhenMolecule.prototype.centreOn = function (glRef, selectionCid) {
+MoorhenMolecule.prototype.centreOn = function (glRef, selectionCid, animate=true) {
     //Note add selection to permit centringh on subset
     let promise
     if (this.atomsDirty) {
@@ -337,7 +337,11 @@ MoorhenMolecule.prototype.centreOn = function (glRef, selectionCid) {
         let selectionCentre = centreOnGemmiAtoms(selectionAtoms)
 
         return new Promise((resolve, reject) => {
-            glRef.current.setOriginAnimated(selectionCentre);
+            if (animate) {
+                glRef.current.setOriginAnimated(selectionCentre);
+            } else {
+                glRef.current.setOrigin(selectionCentre);
+            }
             resolve(true);
         })
     })


### PR DESCRIPTION
After this update, removing the molecule or the map that was connected will make the score toast disappear. Also animations when centering on a molecule that was just loaded are turned off.