### PR TITLE
Enable shortcuts on the residue in the centre rather than hovered residue

### DIFF
--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -280,11 +280,15 @@ export const MoorhenMoleculeCard = (props) => {
     const handleUndo = async () => {
         await props.molecule.undo(props.glRef)
         props.setCurrentDropdownMolNo(-1)
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: props.molecule.molNo} })
+        document.dispatchEvent(mapUpdateEvent)
     }
 
     const handleRedo = async () => {
         await props.molecule.redo(props.glRef)
         props.setCurrentDropdownMolNo(-1)
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: props.molecule.molNo} })
+        document.dispatchEvent(mapUpdateEvent)
     }
 
     const handleCentering = () => {

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -16,7 +16,7 @@ export const MoorhenPreferencesMenu = (props) => {
         showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface,
         defaultBondSmoothness, setDefaultBondSmoothness, showScoresToast, setShowScoresToast,
         defaultUpdatingScores, setDefaultUpdatingScores, drawFPS, setDrawFPS, wheelSensitivityFactor,
-        setWheelSensitivityFactor
+        setWheelSensitivityFactor, shortcutOnHoveredAtom, setShortcutOnHoveredAtom
      } = props;
 
     const [showModal, setShowModal] = useState(null);
@@ -114,6 +114,13 @@ export const MoorhenPreferencesMenu = (props) => {
                             checked={makeBackups}
                             onChange={() => { setMakeBackups(!makeBackups) }}
                             label="Make molecule backups"/>
+                    </InputGroup>
+                    <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                        <Form.Check 
+                            type="switch"
+                            checked={shortcutOnHoveredAtom}
+                            onChange={() => { setShortcutOnHoveredAtom(!shortcutOnHoveredAtom) }}
+                            label="Hover on residue to use shortcuts"/>
                     </InputGroup>
                     <MoorhenScoresToastPreferencesMenuItem
                         showScoresToast={showScoresToast}

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -24,7 +24,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.12',
+        version: '0.0.13',
         darkMode: false, 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
@@ -41,6 +41,7 @@ const getDefaultValues = () => {
         defaultMapSurface: false,
         defaultBondSmoothness: 1,
         showScoresToast: true,
+        shortcutOnHoveredAtom: true,
         defaultUpdatingScores: ['Rfree', 'Rfactor', 'Moorhen Points'],
         shortCuts: {
             "sphere_refine": {
@@ -177,6 +178,7 @@ const PreferencesContextProvider = ({ children }) => {
     const [defaultMapSurface, setDefaultMapSurface] = useState(null)
     const [defaultBondSmoothness, setDefaultBondSmoothness] = useState(null)
     const [showScoresToast, setShowScoresToast] = useState(null)
+    const [shortcutOnHoveredAtom, setShortcutOnHoveredAtom] = useState(null)
     const [defaultUpdatingScores, setDefaultUpdatingScores] = useReducer(itemReducer, null)
 
     const restoreDefaults = (defaultValues)=> {
@@ -199,6 +201,7 @@ const PreferencesContextProvider = ({ children }) => {
         setDefaultUpdatingScores({action: 'Overwrite', items: defaultValues.defaultUpdatingScores})
         setDrawFPS(defaultValues.drawFPS)
         setWheelSensitivityFactor(defaultValues.wheelSensitivityFactor)
+        setShortcutOnHoveredAtom(defaultValues.shortcutOnHoveredAtom)
     }
 
     /**
@@ -230,6 +233,7 @@ const PreferencesContextProvider = ({ children }) => {
                     localforage.getItem('defaultUpdatingScores'),
                     localforage.getItem('drawFPS'),
                     localforage.getItem('wheelSensitivityFactor'),
+                    localforage.getItem('shortcutOnHoveredAtom'),
                     ])
                 
                 console.log('Retrieved the following preferences from local storage: ', response)
@@ -261,6 +265,7 @@ const PreferencesContextProvider = ({ children }) => {
                     setDefaultUpdatingScores({action: 'Overwrite', items: response[16]})
                     setDrawFPS(response[17])
                     setWheelSensitivityFactor(response[18])
+                    setShortcutOnHoveredAtom(response[19])
                 }                
                 
             } catch (err) {
@@ -277,6 +282,15 @@ const PreferencesContextProvider = ({ children }) => {
         fetchStoredPreferences();
         
     }, []);
+
+    useMemo(() => {
+
+        if (shortcutOnHoveredAtom === null) {
+            return
+        }
+       
+        updateStoredPreferences('shortcutOnHoveredAtom', shortcutOnHoveredAtom);
+    }, [shortcutOnHoveredAtom]);
 
     useMemo(() => {
 
@@ -448,7 +462,7 @@ const PreferencesContextProvider = ({ children }) => {
         makeBackups, setMakeBackups, showShortcutToast, setShowShortcutToast, defaultMapSurface,
         setDefaultMapSurface, defaultBondSmoothness, setDefaultBondSmoothness, showScoresToast, 
         setShowScoresToast, defaultUpdatingScores, setDefaultUpdatingScores, drawFPS, setDrawFPS,
-        wheelSensitivityFactor, setWheelSensitivityFactor
+        wheelSensitivityFactor, setWheelSensitivityFactor, shortcutOnHoveredAtom, setShortcutOnHoveredAtom
     }
 
     return (


### PR DESCRIPTION
This can be controlled using the preferences menu. At the moment this is only available with flip_peptide due to issues with the cid returned by `get_active_atom`