### PR TITLE
Fix sliders and other updates

### DIFF
--- a/baby-gru/src/components/MoorhenButtonBar.js
+++ b/baby-gru/src/components/MoorhenButtonBar.js
@@ -3,7 +3,7 @@ import { ButtonGroup, Carousel } from "react-bootstrap"
 import { MoorhenAutofitRotamerButton, MoorhenFlipPeptideButton, MoorhenSideChain180Button, MoorhenAddTerminalResidueDirectlyUsingCidButton,
         MoorhenEigenFlipLigandButton, MoorhenJedFlipFalseButton, MoorhenJedFlipTrueButton, MoorhenConvertCisTransButton, MoorhenAddSimpleButton,
         MoorhenRefineResiduesUsingAtomCidButton, MoorhenDeleteUsingCidButton, MoorhenMutateButton, MoorhenRotateTranslateZoneButton,
-        MoorhenAddSideChainButton, MoorhenAddAltConfButton } from "./MoorhenSimpleEditButton"
+        MoorhenAddAltConfButton } from "./MoorhenSimpleEditButton"
 
 export const MoorhenButtonBar = (props) => {
     const [selectedButtonIndex, setSelectedButtonIndex] = useState(null);

--- a/baby-gru/src/components/MoorhenButtonBar.js
+++ b/baby-gru/src/components/MoorhenButtonBar.js
@@ -29,6 +29,9 @@ export const MoorhenButtonBar = (props) => {
 
         (<MoorhenAddTerminalResidueDirectlyUsingCidButton {...props} key='add-terminal-residue' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="6" />),
+        
+        (<MoorhenAddSimpleButton {...props} key='add-simple' selectedButtonIndex={selectedButtonIndex}
+            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />),
 
         (<MoorhenEigenFlipLigandButton {...props} key='eigen-flip' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="7" />),
@@ -41,9 +44,6 @@ export const MoorhenButtonBar = (props) => {
 
         (<MoorhenRotateTranslateZoneButton {...props} key='rotate-translate-zone' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="10" />),
-
-        (<MoorhenAddSimpleButton {...props} key='add-simple' selectedButtonIndex={selectedButtonIndex}
-            setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="11" />),
         
         (<MoorhenAddAltConfButton {...props} key='add-alt-conf' selectedButtonIndex={selectedButtonIndex}
             setSelectedButtonIndex={setSelectedButtonIndex} buttonIndex="13" />),

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -417,7 +417,7 @@ export const MoorhenContainer = (props) => {
                             }
                         }}>
                         <Accordion.Item eventKey="showDisplayObjects" style={{ width: sideBarWidth, padding: '0', margin: '0' }} >
-                            <Accordion.Header style={{ padding: '0', margin: '0', height: '4rem' }}>Display Objects</Accordion.Header>
+                            <Accordion.Header style={{ padding: '0', margin: '0', height: '4rem' }}>Models and maps</Accordion.Header>
                             <Accordion.Body className='side-bar-accordion-body scroller' style={{ overflowY: 'auto', height: displayObjectsAccordionBodyHeight, padding: '0.5rem' }}>
                                 {molecules.length === 0 && maps.length === 0 ? "No data files loaded" : <MoorhenDisplayObjects {...collectedProps} />}
                             </Accordion.Body>

--- a/baby-gru/src/components/MoorhenDifferenceMapPeaks.js
+++ b/baby-gru/src/components/MoorhenDifferenceMapPeaks.js
@@ -307,7 +307,7 @@ export const MoorhenDifferenceMapPeaks = (props) => {
                             </Col>
                             <Col style={{justifyContent:'center', alignContent:'center', alignItems:'center', display:'flex'}}>
                                 <Form.Group controlId="rmsdSlider" style={{margin:'0.5rem', width: '100%'}}>
-                                    <MoorhenSlider minVal={2.5} maxVal={7.0} logScale={false} sliderTitle="RMSD" intialValue={4.5} externalValue={selectedRmsd} setExternalValue={setSelectedRmsd}/>
+                                    <MoorhenSlider minVal={2.5} maxVal={7.0} logScale={false} sliderTitle="RMSD" initialValue={4.5} externalValue={selectedRmsd} setExternalValue={setSelectedRmsd}/>
                                 </Form.Group>
                             </Col>
                         </Row>

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -265,8 +265,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
-        document.dispatchEvent(originChangeEvent);
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(mapUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -280,8 +280,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
-        document.dispatchEvent(originChangeEvent);
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(mapUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -295,8 +295,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
-        document.dispatchEvent(originChangeEvent);
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(mapUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -310,8 +310,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const originChangeEvent = new CustomEvent("originChange", { "detail": glRef.current.origin });
-        document.dispatchEvent(originChangeEvent);
+        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(mapUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -246,12 +246,12 @@ export const MoorhenMapCard = (props) => {
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringLevel" className="mb-3">
-                        <MoorhenSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" isDisabled={!cootContour} intialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
+                        <MoorhenSlider minVal={0.01} maxVal={5} logScale={true} sliderTitle="Level" isDisabled={!cootContour} initialValue={props.initialContour} externalValue={mapContourLevel} setExternalValue={setMapContourLevel}/>
                     </Form.Group>
                 </Col>
                 <Col>
                     <Form.Group controlId="contouringRadius" className="mb-3">
-                        <MoorhenSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" isDisabled={!cootContour} intialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
+                        <MoorhenSlider minVal={0.01} maxVal={100} logScale={false} sliderTitle="Radius" isDisabled={!cootContour} initialValue={props.initialRadius} externalValue={mapRadius} setExternalValue={setMapRadius}/>
                     </Form.Group>
                 </Col>
             </Row>

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1270,11 +1270,10 @@ export const MoorhenAboutMenuItem = (props) => {
 }
 
 export const MoorhenClipFogMenuItem = (props) => {
-
-    const [zclipFront, setZclipFront] = useState(5)
-    const [zclipBack, setZclipBack] = useState(5)
-    const [zfogFront, setZfogFront] = useState(5)
-    const [zfogBack, setZfogBack] = useState(5)
+    const [zclipFront, setZclipFront] = useState(500 + props.glRef.current.gl_clipPlane0[3])
+    const [zclipBack, setZclipBack] = useState(props.glRef.current.gl_clipPlane1[3] - 500)
+    const [zfogFront, setZfogFront] = useState(500 - props.glRef.current.gl_fog_start)
+    const [zfogBack, setZfogBack] = useState(props.glRef.current.gl_fog_end - 500)
 
     useEffect(() => {
         if (props.glRef.current && props.glRef.current.gl_clipPlane0) {
@@ -1283,24 +1282,12 @@ export const MoorhenClipFogMenuItem = (props) => {
             setZfogFront(500 - props.glRef.current.gl_fog_start)
             setZfogBack(props.glRef.current.gl_fog_end - 500)
         }
-    })
-
-    const fractionalLog = (minVal, maxVal, val) => {
-        if (minVal < 0.00001) minVal = 0.0001
-        if (maxVal < 0.0001) maxVal = 0.0001
-        if (val < 0.0001) val = 0.0001
-        return 1 + 99 * ((Math.log10(val) - Math.log10(minVal)) / (Math.log10(maxVal) - Math.log10(minVal)))
-    }
-
-    const initialClipFront = fractionalLog(0.1, 1000, 500 + props.glRef.current.gl_clipPlane0[3])
-    const initialClipBack = fractionalLog(0.1, 1000, props.glRef.current.gl_clipPlane1[3])
-    const initialFogFront = fractionalLog(0.1, 1000, 500 - props.glRef.current.gl_fog_end)
-    const initialFogBack = fractionalLog(0.1, 1000, props.glRef.current.gl_fog_end - 500)
+    }, [props.glRef.current.gl_clipPlane, props.glRef.current.gl_clipPlane1, props.glRef.current.gl_fog_start, props.glRef.current.gl_fog_end])
 
     const panelContent = <div style={{ minWidth: "20rem" }}>
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Front clip"
-            initialValue={initialClipFront}
+            intialValue={500 + props.glRef.current.gl_clipPlane0[3]}
             externalValue={zclipFront}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_clipPlane0[3] = newValue - 500
@@ -1309,7 +1296,7 @@ export const MoorhenClipFogMenuItem = (props) => {
             }} />
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Back clip"
-            initialValue={initialClipBack}
+            intialValue={props.glRef.current.gl_clipPlane1[3] - 500}
             externalValue={zclipBack}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_clipPlane1[3] = 500 + newValue
@@ -1318,7 +1305,7 @@ export const MoorhenClipFogMenuItem = (props) => {
             }} />
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Front zFog"
-            initialValue={initialFogFront}
+            intialValue={500 - props.glRef.current.gl_fog_start}
             externalValue={zfogFront}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_fog_start = 500 - newValue
@@ -1328,7 +1315,7 @@ export const MoorhenClipFogMenuItem = (props) => {
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Back zFog"
             externalValue={zfogBack}
-            initialValue={initialFogBack}
+            intialValue={props.glRef.current.gl_fog_end - 500}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_fog_end = newValue + 500
                 props.glRef.current.drawScene()

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -530,7 +530,7 @@ export const MoorhenMapSettingsMenuItem = (props) => {
                     label="Activate lit lines" />
             }
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenMapOpacitySlider">
-                <MoorhenSlider minVal={0.0} maxVal={1.0} logScale={false} sliderTitle="Opacity" intialValue={props.mapOpacity} externalValue={props.mapOpacity} setExternalValue={props.setMapOpacity} />
+                <MoorhenSlider minVal={0.0} maxVal={1.0} logScale={false} sliderTitle="Opacity" initialValue={props.mapOpacity} externalValue={props.mapOpacity} setExternalValue={props.setMapOpacity} />
             </Form.Group>
         </>
     return <MoorhenMenuItem
@@ -549,10 +549,10 @@ export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
     const panelContent =
         <>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenBondWidthSlider">
-                <MoorhenSlider minVal={0.05} maxVal={0.5} logScale={false} sliderTitle="Bond width" intialValue={0.1} externalValue={props.bondWidth} setExternalValue={props.setBondWidth} />
+                <MoorhenSlider minVal={0.05} maxVal={0.5} logScale={false} sliderTitle="Bond width" initialValue={0.1} externalValue={props.bondWidth} setExternalValue={props.setBondWidth} />
             </Form.Group>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenRadiusBondRatioSlider">
-                <MoorhenSlider minVal={1.0} maxVal={3.5} logScale={false} sliderTitle="Radius-Bond ratio" intialValue={1.5} externalValue={props.atomRadiusBondRatio} setExternalValue={props.setAtomRadiusBondRatio} />
+                <MoorhenSlider minVal={1.0} maxVal={3.5} logScale={false} sliderTitle="Radius-Bond ratio" initialValue={1.5} externalValue={props.atomRadiusBondRatio} setExternalValue={props.setAtomRadiusBondRatio} />
             </Form.Group>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenSmoothnessSelector">
                 <Form.Label>Smoothness</Form.Label>
@@ -577,16 +577,16 @@ export const MoorhenMoleculeGaussianSurfaceSettingsMenuItem = (props) => {
     const panelContent =
         <>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenGausSurfSigmaSlider">
-                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Sigma" intialValue={4.4} externalValue={props.surfaceSigma} setExternalValue={props.setSurfaceSigma} />
+                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Sigma" initialValue={4.4} externalValue={props.surfaceSigma} setExternalValue={props.setSurfaceSigma} />
             </Form.Group>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenGausSurfLevelSlider">
-                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Contour level" intialValue={4.0} externalValue={props.surfaceLevel} setExternalValue={props.setSurfaceLevel} />
+                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Contour level" initialValue={4.0} externalValue={props.surfaceLevel} setExternalValue={props.setSurfaceLevel} />
             </Form.Group>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenGausSurfRadiusSlider">
-                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Box radius" intialValue={5.0} externalValue={props.surfaceRadius} setExternalValue={props.setSurfaceRadius} />
+                <MoorhenSlider minVal={0.01} maxVal={10} logScale={false} sliderTitle="Box radius" initialValue={5.0} externalValue={props.surfaceRadius} setExternalValue={props.setSurfaceRadius} />
             </Form.Group>
             <Form.Group className="mb-3" style={{ width: '10rem', margin: '0' }} controlId="MoorhenSurfGridScaleSlider">
-                <MoorhenSlider minVal={0.01} maxVal={1.5} logScale={false} sliderTitle="Grid scale" intialValue={0.7} externalValue={props.surfaceGridScale} setExternalValue={props.setSurfaceGridScale} />
+                <MoorhenSlider minVal={0.01} maxVal={1.5} logScale={false} sliderTitle="Grid scale" initialValue={0.7} externalValue={props.surfaceGridScale} setExternalValue={props.setSurfaceGridScale} />
             </Form.Group>
         </>
 
@@ -1287,7 +1287,7 @@ export const MoorhenClipFogMenuItem = (props) => {
     const panelContent = <div style={{ minWidth: "20rem" }}>
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Front clip"
-            intialValue={500 + props.glRef.current.gl_clipPlane0[3]}
+            initialValue={500 + props.glRef.current.gl_clipPlane0[3]}
             externalValue={zclipFront}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_clipPlane0[3] = newValue - 500
@@ -1296,7 +1296,7 @@ export const MoorhenClipFogMenuItem = (props) => {
             }} />
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Back clip"
-            intialValue={props.glRef.current.gl_clipPlane1[3] - 500}
+            initialValue={props.glRef.current.gl_clipPlane1[3] - 500}
             externalValue={zclipBack}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_clipPlane1[3] = 500 + newValue
@@ -1305,7 +1305,7 @@ export const MoorhenClipFogMenuItem = (props) => {
             }} />
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Front zFog"
-            intialValue={500 - props.glRef.current.gl_fog_start}
+            initialValue={500 - props.glRef.current.gl_fog_start}
             externalValue={zfogFront}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_fog_start = 500 - newValue
@@ -1315,7 +1315,7 @@ export const MoorhenClipFogMenuItem = (props) => {
         <MoorhenSlider minVal={0.1} maxVal={1000} logScale={true}
             sliderTitle="Back zFog"
             externalValue={zfogBack}
-            intialValue={props.glRef.current.gl_fog_end - 500}
+            initialValue={props.glRef.current.gl_fog_end - 500}
             setExternalValue={(newValue) => {
                 props.glRef.current.gl_fog_end = newValue + 500
                 props.glRef.current.drawScene()

--- a/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
@@ -177,7 +177,7 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
                             </Col>
                             <Col style={{justifyContent:'center', alignContent:'center', alignItems:'center', display:'flex'}}>
                                 <Form.Group controlId="rmsdSlider" style={{margin:'0.5rem', width: '100%'}}>
-                                    <MoorhenSlider minVal={2.5} maxVal={7.0} logScale={false} sliderTitle="RMSD" intialValue={4.5} externalValue={selectedRmsd} setExternalValue={setSelectedRmsd}/>
+                                    <MoorhenSlider minVal={2.5} maxVal={7.0} logScale={false} sliderTitle="RMSD" initialValue={4.5} externalValue={selectedRmsd} setExternalValue={setSelectedRmsd}/>
                                 </Form.Group>
                             </Col>
                         </Row>

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -136,13 +136,13 @@ export const MoorhenPreferencesMenu = (props) => {
                     />
                     <hr></hr>
                     <Form.Group controlId="mouseSensitivitySlider" style={{paddingTop:'0rem', paddingBottom:'0.5rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
-                        <MoorhenSlider minVal={0.1} maxVal={10.0} logScale={false} sliderTitle="Mouse sensitivity" intialValue={2.5} externalValue={mouseSensitivity} setExternalValue={setMouseSensitivity}/>
+                        <MoorhenSlider minVal={0.1} maxVal={10.0} logScale={false} sliderTitle="Mouse sensitivity" initialValue={2.5} externalValue={mouseSensitivity} setExternalValue={setMouseSensitivity}/>
                     </Form.Group>
                     <Form.Group controlId="wheelSensitivitySlider" style={{paddingTop:'0.5rem', paddingBottom:'0rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
-                        <MoorhenSlider minVal={0.1} maxVal={9.9} logScale={false} sliderTitle="Mouse wheel zoom sensitivity" intialValue={1.0} externalValue={wheelSensitivityFactor} setExternalValue={setWheelSensitivityFactor}/>
+                        <MoorhenSlider minVal={0.1} maxVal={9.9} logScale={false} sliderTitle="Mouse wheel zoom sensitivity" initialValue={1.0} externalValue={wheelSensitivityFactor} setExternalValue={setWheelSensitivityFactor}/>
                     </Form.Group>
                     <Form.Group controlId="mapLineWidthSlider" style={{paddingTop:'0.5rem', paddingBottom:'0rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
-                        <MoorhenSlider minVal={0.1} maxVal={5.0} logScale={true} sliderTitle="Map lines thickness" intialValue={2.5} externalValue={mapLineWidth} setExternalValue={setMapLineWidth}/>
+                        <MoorhenSlider minVal={0.1} maxVal={5.0} logScale={true} sliderTitle="Map lines thickness" initialValue={2.5} externalValue={mapLineWidth} setExternalValue={setMapLineWidth}/>
                     </Form.Group>
                     <hr></hr>
                     <MenuItem variant="success" onClick={() => setShowModal(true)} id='configure-shortcuts-menu-item' style={{marginTop:'0rem'}}>

--- a/baby-gru/src/components/MoorhenSlider.js
+++ b/baby-gru/src/components/MoorhenSlider.js
@@ -13,7 +13,7 @@ export default function MoorhenSlider(props) {
         }
     }
 
-    const [value, setValue] = React.useState(convertInitValueToScale(props.intialValue));
+    const [value, setValue] = React.useState(convertInitValueToScale(props.initialValue));
     const [externalValue, setExternalValue] = React.useState(props.externalValue)
 
     React.useEffect(() => {


### PR DESCRIPTION
This update includes:
- Fix bug causing sliders at the clipping and fogging menu not to be set at the right value
- Update maps when using arrows to move the view
- Switch order of jed flip and add simple buttons as requested
- Rename display objects and take the checkboxes outside the accordion