### PR TITLE
Add plddt colour scheme and other changes

### DIFF
--- a/baby-gru/src/components/MoorhenColouRules.js
+++ b/baby-gru/src/components/MoorhenColouRules.js
@@ -94,7 +94,7 @@ export const MoorhenColourRules = (props) => {
         if (ruleList.length === 0) {
             return
         }
-        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel);
+        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)
         await selectedMolecule.setColourRules(props.glRef, ruleList, true)
     }, [selectedModel, ruleList, props.molecules, props.glRef])
 
@@ -129,7 +129,6 @@ export const MoorhenColourRules = (props) => {
                 },
                 isMultiColourRule: true,
                 ruleType: `${colourPreset}`,
-                color: selectedColour,
                 label: `//*`,
             }
         }
@@ -168,10 +167,17 @@ export const MoorhenColourRules = (props) => {
                             {rule.label}
                         </Col>
                         <Col style={{ display: 'flex', justifyContent: 'right', alignItems:'center' }}>
-                            {rule.isMultiColourRule ?
-                            <img className="colour-rule-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
+                            {!rule.isMultiColourRule ?
+                                <div style={{borderColor: 'black', borderWidth:'5px', backgroundColor: rule.color, height:'20px', width:'20px', margin: '0.1rem'}}/>
+                            : rule.ruleType === "b-factor" ?
+                                <img className="colour-rule-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
                             :
-                             <div style={{borderColor: 'black', borderWidth:'5px', backgroundColor: rule.color, height:'20px', width:'20px', margin: '0.1rem'}}/>
+                            <>
+                                <div style={{borderColor: 'rgb(255, 125, 69)', borderWidth:'5px', backgroundColor:  'rgb(255, 125, 69)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                                <div style={{borderColor: 'rgb(255, 219, 19)', borderWidth:'5px', backgroundColor: 'rgb(255, 219, 19)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                                <div style={{borderColor: 'rgb(101, 203, 243)', borderWidth:'5px', backgroundColor: 'rgb(101, 203, 243)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                                <div style={{borderColor: 'rgb(0, 83, 214)', borderWidth:'5px', backgroundColor: 'rgb(0, 83, 214)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                            </>
                             }
                             <OverlayTrigger
                                 placement="top"
@@ -239,7 +245,8 @@ export const MoorhenColourRules = (props) => {
                                 <Form.Group style={{ margin: '0.1rem', width: '100%' }}>
                                     <Form.Label>Color preset</Form.Label>
                                     <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'b-factor'} onChange={(val) => setColourPreset(val.target.value)}>
-                                        <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
+                                    <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
+                                    <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>
                                     </FormSelect>
                                 </Form.Group>
                             }

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -51,7 +51,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
         hover: [],
         transformation: { origin: [0, 0, 0], quat: null, centre: [0, 0, 0] }
     }
-    this.urlPrefix = (typeof urlPrefix === 'undefined' ? "." : urlPrefix);
+    this.urlPrefix = (typeof urlPrefix === 'undefined' ? "." : urlPrefix)
 };
 
 MoorhenMolecule.prototype.setBackgroundColour = function (backgroundColour) {
@@ -1501,21 +1501,21 @@ MoorhenMolecule.prototype.hasVisibleBuffers = function (excludeBuffers = ['hover
     return visibleDisplayBuffers.length !== 0
 }
 
-MoorhenMolecule.prototype.fetchCurrentColourRules = async () => {
+MoorhenMolecule.prototype.fetchCurrentColourRules = async function() {
     let rules = []
     const response = await this.commandCentre.current.cootCommand({
-        message:'coot_command',
+        message: 'coot_command',
         command: "get_colour_rules", 
-        returnType:'colour_rules',
-        commandArgs:[this.molNo], 
+        returnType: 'colour_rules',
+        commandArgs: [this.molNo], 
     })
 
     response.data.result.result.forEach(rule => {
         rules.push({
             commandInput: {
-                message:'coot_command',
+                message: 'coot_command',
                 command: 'add_colour_rule', 
-                returnType:'status',
+                returnType: 'status',
                 commandArgs: [this.molNo, rule.first, rule.second]
             },
             isMultiColourRule: false,
@@ -1528,13 +1528,13 @@ MoorhenMolecule.prototype.fetchCurrentColourRules = async () => {
     this.colourRules = rules
 }
 
-MoorhenMolecule.prototype.setColourRules = async (glRef, ruleList, redraw=false) => {
+MoorhenMolecule.prototype.setColourRules = async function(glRef, ruleList, redraw=false) {
     this.colourRules = [...ruleList]
 
     await this.commandCentre.current.cootCommand({
-        message:'coot_command',
+        message: 'coot_command',
         command: "delete_colour_rules", 
-        returnType:'status',
+        returnType: 'status',
         commandArgs: [this.molNo], 
     })
 

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -1500,3 +1500,52 @@ MoorhenMolecule.prototype.hasVisibleBuffers = function (excludeBuffers = ['hover
     const visibleDisplayBuffers = displayBuffers.filter(displayBuffer => displayBuffer.some(buffer => buffer.visible))
     return visibleDisplayBuffers.length !== 0
 }
+
+MoorhenMolecule.prototype.fetchCurrentColourRules = async () => {
+    let rules = []
+    const response = await this.commandCentre.current.cootCommand({
+        message:'coot_command',
+        command: "get_colour_rules", 
+        returnType:'colour_rules',
+        commandArgs:[this.molNo], 
+    })
+
+    response.data.result.result.forEach(rule => {
+        rules.push({
+            commandInput: {
+                message:'coot_command',
+                command: 'add_colour_rule', 
+                returnType:'status',
+                commandArgs: [this.molNo, rule.first, rule.second]
+            },
+            isMultiColourRule: false,
+            ruleType: 'chain',
+            color: rule.second,
+            label: rule.first
+        })
+    })
+
+    this.colourRules = rules
+}
+
+MoorhenMolecule.prototype.setColourRules = async (glRef, ruleList, redraw=false) => {
+    this.colourRules = [...ruleList]
+
+    await this.commandCentre.current.cootCommand({
+        message:'coot_command',
+        command: "delete_colour_rules", 
+        returnType:'status',
+        commandArgs: [this.molNo], 
+    })
+
+    const promises = this.colourRules.map(rule => 
+        this.commandCentre.current.cootCommand(rule.commandInput)
+    )
+
+    await Promise.all(promises)
+    
+    if (redraw) {
+        this.setAtomsDirty(true)
+        await this.redraw(glRef)
+    }
+}

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -511,7 +511,7 @@ export  function rgbToHex(r, g, b) {
     return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b)
 }
 
-const getBfactorColourRules = (imol, bFactors) => {
+const getBfactorColourRules = (bFactors) => {
     const bFactorList = bFactors.map(item => item.bFactor)
     const min = Math.min(...bFactorList)
     const max = Math.max(...bFactorList)
@@ -542,6 +542,32 @@ const getBfactorColourRules = (imol, bFactors) => {
     return bFactors.map(item => `${item.cid}^${getColour(item.bFactor)}`).join('|')
 }
 
+const getPlddtColourRules = (plddtList) => {
+    const getColour = (plddt) => {
+        let r, g, b
+        if(plddt <= 50) {
+            r = 255
+            g = 125
+            b = 69
+        } else if (plddt <= 70) {
+            r = 255
+            g = 219
+            b = 19
+        } else if (plddt < 90) {
+            r = 101
+            g = 203
+            b = 243
+        } else {
+            r = 0
+            g = 83
+            b = 214
+        }
+        return rgbToHex(r, g, b)
+    }
+
+    return plddtList.map(item => `${item.cid}^${getColour(item.bFactor)}`).join('|')
+}
+
 export const getMultiColourRuleArgs = (molecule, ruleType) => {
 
     let multiRulesArgs
@@ -549,10 +575,11 @@ export const getMultiColourRuleArgs = (molecule, ruleType) => {
     switch (ruleType) {
         case 'b-factor':
             const bFactors = getMoleculeBfactors(molecule.gemmiStructure.clone())
-            multiRulesArgs = [molecule.molNo, getBfactorColourRules(molecule.molNo, bFactors)]
+            multiRulesArgs = [molecule.molNo, getBfactorColourRules(bFactors)]
             break;
         case 'af2-plddt':
-            //cootCommands = getPlddtColourRules(molecule)
+            const plddt = getMoleculeBfactors(molecule.gemmiStructure.clone())
+            multiRulesArgs = [molecule.molNo, getPlddtColourRules(plddt)]
             break;
         default:
             console.log('Unrecognised colour rule...')


### PR DESCRIPTION
This adds the plddt colour rule, which is loaded by default into AF2 models. Additionally, the code to handle colour rules has been refactored into `MoorhenMolecule`.