### PR TITLE
Refactor ligand card code and enable SVG

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -19,7 +19,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "d3": "^5.15.0",
     "gl-matrix": "^3.4.3",
-    "html-react-parser": "^1.4.12",
+    "html-react-parser": "^1.4.14",
     "localforage": "^1.10.0",
     "nested-worker": "git+https://github.com/johanholmerin/nested-worker.git#semver:^1.0.0",
     "pako": "^2.0.4",

--- a/baby-gru/src/components/MoorhenLigandList.js
+++ b/baby-gru/src/components/MoorhenLigandList.js
@@ -1,6 +1,8 @@
-import { BubbleChartOutlined } from "@mui/icons-material";
+import { Settings } from "@mui/icons-material";
 import React, { useEffect, useState } from "react";
-import { Card, Form, Row, Col, Button, DropdownButton } from "react-bootstrap";
+import { Card, Form, Row, Col, DropdownButton, Stack } from "react-bootstrap";
+import parse from 'html-react-parser'
+import { MenuItem } from "@mui/material";
 
 export const MoorhenLigandList = (props) => {
     const [ligandList, setLigandList] = useState([])
@@ -10,7 +12,7 @@ export const MoorhenLigandList = (props) => {
         const result = await props.commandCentre.current.cootCommand({
             returnType: "string",
             command: 'get_svg_for_residue_type',
-            commandArgs: [imol, compId],
+            commandArgs: [imol, compId, props.darkMode],
         }, true)
         
         const parser = new DOMParser()
@@ -63,12 +65,14 @@ export const MoorhenLigandList = (props) => {
 
         xmin -= 20
         ymin -= 20
-        xmax += 20
-        ymax += 20
+        //xmax -= 120
+        ymax -= 100
         let svgs = doc.getElementsByTagName("svg")
         const viewBoxStr = xmin+" "+ymin+" "+xmax+" "+ymax
         for (let item of svgs) {
             item.setAttribute("viewBox" , viewBoxStr)
+            item.setAttribute("width" , "100%")
+            item.setAttribute("height" , "100%")
             theText = item.outerHTML
         }
         
@@ -107,69 +111,69 @@ export const MoorhenLigandList = (props) => {
                                 const keycf = `chemical_features-${ligand.chainName}/${ligand.resNum}(${ligand.resName})`
                                 return <Card key={index} style={{marginTop: '0.5rem'}}>
                                             <Card.Body style={{padding:'0.5rem'}}>
-                                                <Row style={{display:'flex', justifyContent:'between'}}>
-                                                    <Col style={{alignItems:'center', justifyContent:'left', display:'flex'}}>
-                                                        {`${ligand.chainName}/${ligand.resNum}(${ligand.resName})`}
+                                                <Stack direction="horizontal" gap={2} style={{alignItems: 'center', height:'10rem'}}>
+                                                    <Col style={{height: '100%'}}>
+                                                        {ligand.svg ? parse(ligand.svg) : null}
                                                     </Col>
                                                     <Col className='col-3' style={{justifyContent: 'right', display:'flex'}}>
-                                                        <DropdownButton
-                                                            key="dropDownButton"
-                                                            title={<BubbleChartOutlined/>}
-                                                            variant="outlined"
-                                                        >
-                                                            <div style={{maxHeight: '6rem', overflowY: 'auto', width:'15rem'}}>
-                                                            <Form.Check
-                                                                key={keycd}
-                                                                label={"Contact dots"}
-                                                                type="checkbox"
-                                                                variant="outline"
-                                                                style={{'margin': '0.5rem'}}
-                                                                checked={showState[keycd]}
-                                                                onChange={(e) => {
-                                                                    if (e.target.checked) {
-                                                                        props.molecule.show(keycd, props.glRef)
-                                                                        const changedState = { ...showState }
-                                                                        changedState[keycd] = true
-                                                                        setShowState(changedState)
-                                                                    }
-                                                                    else {
-                                                                        props.molecule.hide(keycd, props.glRef)
-                                                                        const changedState = { ...showState }
-                                                                        changedState[keycd] = false
-                                                                        setShowState(changedState)
-                                                                    }
-                                                            }}/>
-                                                            <Form.Check
-                                                                key={keycf}
-                                                                label={"Chemical features"}
-                                                                type="checkbox"
-                                                                variant="outline"
-                                                                checked={showState[keycf]}
-                                                                style={{'margin': '0.5rem'}}
-                                                                onChange={(e) => {
-                                                                    if (e.target.checked) {
-                                                                        props.molecule.show(keycf, props.glRef)
-                                                                        const changedState = { ...showState }
-                                                                        changedState[keycf] = true
-                                                                        setShowState(changedState)
-                                                                    }
-                                                                    else {
-                                                                        props.molecule.hide(keycf, props.glRef)
-                                                                        const changedState = { ...showState }
-                                                                        changedState[keycf] = false
-                                                                        setShowState(changedState)
-                                                                    }
-                                                            }}/>
-                                                            </div>
-                                                        </DropdownButton>
-                                                        <Button onClick={() => {props.molecule.centreOn(props.glRef, `/*/${ligand.chainName}/${ligand.resNum}-${ligand.resNum}/*`)}}>
-                                                            View
-                                                        </Button>
+                                                        <Stack gap={2} style={{alignItems: 'center'}}>
+                                                            <DropdownButton
+                                                                key="dropDownButton"
+                                                                title={`${ligand.chainName}/${ligand.resNum}(${ligand.resName})`}
+                                                                variant="outlined"
+                                                                >
+                                                                <MenuItem onClick={() => {props.molecule.centreOn(props.glRef, `/*/${ligand.chainName}/${ligand.resNum}-${ligand.resNum}/*`)}}>
+                                                                    Center on ligand
+                                                                </MenuItem>
+                                                                <hr></hr>
+                                                                <div style={{maxHeight: '6rem', overflowY: 'auto', width:'15rem'}}>
+                                                                <Form.Check
+                                                                    key={keycd}
+                                                                    label={"Contact dots"}
+                                                                    type="checkbox"
+                                                                    variant="outline"
+                                                                    style={{'margin': '0.5rem'}}
+                                                                    checked={showState[keycd]}
+                                                                    onChange={(e) => {
+                                                                        if (e.target.checked) {
+                                                                            props.molecule.show(keycd, props.glRef)
+                                                                            const changedState = { ...showState }
+                                                                            changedState[keycd] = true
+                                                                            setShowState(changedState)
+                                                                        }
+                                                                        else {
+                                                                            props.molecule.hide(keycd, props.glRef)
+                                                                            const changedState = { ...showState }
+                                                                            changedState[keycd] = false
+                                                                            setShowState(changedState)
+                                                                        }
+                                                                }}/>
+                                                                <Form.Check
+                                                                    key={keycf}
+                                                                    label={"Chemical features"}
+                                                                    type="checkbox"
+                                                                    variant="outline"
+                                                                    checked={showState[keycf]}
+                                                                    style={{'margin': '0.5rem'}}
+                                                                    onChange={(e) => {
+                                                                        if (e.target.checked) {
+                                                                            props.molecule.show(keycf, props.glRef)
+                                                                            const changedState = { ...showState }
+                                                                            changedState[keycf] = true
+                                                                            setShowState(changedState)
+                                                                        }
+                                                                        else {
+                                                                            props.molecule.hide(keycf, props.glRef)
+                                                                            const changedState = { ...showState }
+                                                                            changedState[keycf] = false
+                                                                            setShowState(changedState)
+                                                                        }
+                                                                }}/>
+                                                                </div>
+                                                            </DropdownButton>
+                                                    </Stack>
                                                     </Col>
-                                                </Row>
-                                                <Row>
-                                                <div dangerouslySetInnerHTML={{__html: ligand.svg}}></div>
-                                                </Row>
+                                                </Stack>
                                             </Card.Body>
                                         </Card>
                             })}

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -443,7 +443,7 @@ export const MoorhenMoleculeCard = (props) => {
                 <Accordion.Item eventKey="ligands" style={{ padding: '0', margin: '0' }} >
                     <Accordion.Header style={{ padding: '0', margin: '0' }}>Ligands</Accordion.Header>
                     <Accordion.Body style={{ padding: '0.5rem' }}>
-                        <MoorhenLigandList commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} />
+                        <MoorhenLigandList commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} darkMode={props.darkMode} />
                     </Accordion.Body>
                 </Accordion.Item>
             </Accordion>

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -25,6 +25,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
     this.gemmiStructure = null
     this.sequences = []
     this.colourRules = null
+    this.ligands = null
     this.gaussianSurfaceSettings = {
         sigma: 4.4,
         countourLevel: 4.0,
@@ -66,6 +67,7 @@ MoorhenMolecule.prototype.updateGemmiStructure = async function () {
     this.gemmiStructure = readGemmiStructure(response.data.result.pdbData, this.name)
     window.CCP4Module.gemmi_setup_entities(this.gemmiStructure)
     this.parseSequences()
+    this.updateLigands()
     return Promise.resolve()
 }
 
@@ -218,6 +220,7 @@ MoorhenMolecule.prototype.loadToCootFromString = async function (coordData, name
     $this.gemmiStructure = readGemmiStructure(coordData, $this.name)
     window.CCP4Module.gemmi_setup_entities($this.gemmiStructure)
     $this.parseSequences()
+    $this.updateLigands()
     $this.atomsDirty = false
 
     return this.commandCentre.current.cootCommand({
@@ -303,6 +306,7 @@ MoorhenMolecule.prototype.updateAtoms = function () {
                 $this.gemmiStructure = readGemmiStructure(result.data.result.pdbData, $this.name)
                 window.CCP4Module.gemmi_setup_entities($this.gemmiStructure)
                 $this.parseSequences()
+                $this.updateLigands()
             }
             catch (err) {
                 console.log('Issue parsing coordinates into Gemmi structure', result.data.result.pdbData)
@@ -1412,6 +1416,38 @@ MoorhenMolecule.prototype.redo = async function (glRef) {
     })
     $this.setAtomsDirty(true)
     return $this.redraw(glRef)
+}
+
+MoorhenMolecule.prototype.updateLigands = async function () {
+    let ligandList = []
+    const model = this.gemmiStructure.first_model()
+    
+    try{
+        const chains = model.chains
+        const chainsSize = chains.size()
+        for (let i = 0; i < chainsSize; i++) {
+            const chain = chains.get(i)
+            const chainName = chain.name
+            const ligands = chain.get_ligands_const()
+            const ligandsSize = ligands.size()
+            for (let j = 0; j < ligandsSize; j++) {
+                let ligand = ligands.at(j)
+                const resName = ligand.name
+                const ligandSeqId = ligand.seqid
+                const resNum = ligandSeqId.str()
+                ligandList.push({resName: resName, chainName: chainName, resNum: resNum})
+                ligand.delete()
+                ligandSeqId.delete()
+            }
+            chain.delete()
+            ligands.delete()
+        }
+        chains.delete()
+    } finally {
+        model.delete()
+    }
+
+    this.ligands = ligandList
 }
 
 MoorhenMolecule.prototype.gemmiAtomsForCid = async function (cid) {


### PR DESCRIPTION
This update includes:
- Code related to fetching ligands has been refactored into `MoorhenMolecule` to make it more general
- Update UI for `MoorhenLigandList` so that they include a SVG representation of the ligand 
- Refactor code to include svg into the ligand cards. No longer use `dangerouslySetInnerHTML` and not necessary to keep cached gemmi structure in react component.