### PR TITLE
Minor changes to the UI and other fixes

### DIFF
--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback, useMemo, Fragment } from "react";
 import { Card, Form, Button, Row, Col, DropdownButton } from "react-bootstrap";
-import { doDownload } from '../utils/MoorhenUtils';
+import { doDownload, getNameLabel } from '../utils/MoorhenUtils';
 import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined, DownloadOutlined, Settings } from '@mui/icons-material';
 import MoorhenSlider from "./MoorhenSlider";
 import { MoorhenDeleteDisplayObjectMenuItem, MoorhenRenameDisplayObjectMenuItem } from "./MoorhenMenuItem";
@@ -71,7 +71,7 @@ export const MoorhenMapCard = (props) => {
     }
 
     const getButtonBar = (sideBarWidth) => {
-        const maximumAllowedWidth = sideBarWidth * 0.35
+        const maximumAllowedWidth = sideBarWidth * 0.55
         let currentlyUsedWidth = 0
         let expandedButtons = []
         let compressedButtons = []
@@ -212,7 +212,7 @@ export const MoorhenMapCard = (props) => {
         <Card.Header style={{padding: '0.5rem'}}>
             <Row className='align-items-center'>
             <Col className='align-items-center' style={{display:'flex', justifyContent:'left'}}>
-                    {`#${props.map.molNo} Map ${props.map.name}`}
+                    {getNameLabel(props.map)}
                     <img 
                         className="baby-gru-map-icon"
                         alt="..."

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1455,6 +1455,13 @@ export const MoorhenClipFogMenuItem = (props) => {
                 props.glRef.current.drawScene()
                 setZfogBack(newValue)
             }} />
+        <InputGroup style={{ paddingLeft:'0.1rem', paddingBottom: '0.5rem', width: '25rem'}}>
+            <Form.Check 
+                type="switch"
+                checked={props.resetClippingFogging}
+                onChange={() => { props.setResetClippingFogging(!props.resetClippingFogging) }}
+                label="Reset clipping and fogging on zoom"/>
+        </InputGroup>
     </div>
 
     const onCompleted = () => { props.setPopoverIsShown(false) }

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useReducer } from "react";
 import { Card, Row, Col, Accordion } from "react-bootstrap";
-import { doDownload, sequenceIsValid } from '../utils/MoorhenUtils';
+import { doDownload, sequenceIsValid, getNameLabel} from '../utils/MoorhenUtils';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
 import { MoorhenSequenceViewer } from "./MoorhenSequenceViewer";
 import { MoorhenMoleculeCardButtonBar } from "./MoorhenMoleculeCardButtonBar"
@@ -359,7 +359,7 @@ export const MoorhenMoleculeCard = (props) => {
         <Card.Header style={{ padding: '0.5rem' }}>
             <Row className='align-items-center'>
                 <Col className='align-items-center' style={{ display: 'flex', justifyContent: 'left' }}>
-                    {`#${props.molecule.molNo} Mol. ${props.molecule.name}`}
+                    {getNameLabel(props.molecule)}
                 </Col>
                 <Col style={{ display: 'flex', justifyContent: 'right' }}>
                     <MoorhenMoleculeCardButtonBar

--- a/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
+++ b/baby-gru/src/components/MoorhenMoleculeCardButtonBar.js
@@ -21,38 +21,38 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
 
     const actionButtons = {
         1: {
-            label: "Undo last action",
-            compressed: () => { return (<MenuItem key={1} variant="success" onClick={props.handleUndo} disabled={!props.backupsEnabled}>Undo last action</MenuItem>) },
+            label: props.isVisible ? "Hide molecule" : "Show molecule",
+            compressed: () => { return (<MenuItem key={1} variant="success" onClick={props.handleVisibility}>{props.isVisible ? "Hide molecule" : "Show molecule"}</MenuItem>) },
             expanded: () => {
-                return (<Button key={1} size="sm" variant="outlined" style={{borderWidth: props.backupsEnabled ? '' : '0px'}} onClick={props.handleUndo} disabled={!props.backupsEnabled}>
-                    <UndoOutlined />
+                return (<Button key={1} size="sm" variant="outlined" onClick={props.handleVisibility}>
+                    {props.isVisible ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
                 </Button>)
             }
         },
         2: {
-            label: "Redo previous action",
-            compressed: () => { return (<MenuItem key={2} variant="success" onClick={props.handleRedo} disabled={!props.backupsEnabled}>Redo previous action</MenuItem>) },
+            label: "Undo last action",
+            compressed: () => { return (<MenuItem key={2} variant="success" onClick={props.handleUndo} disabled={!props.backupsEnabled}>Undo last action</MenuItem>) },
             expanded: () => {
-                return (<Button key={2} size="sm" variant="outlined" style={{borderWidth: props.backupsEnabled ? '': '0px'}} onClick={props.handleRedo} disabled={!props.backupsEnabled}>
-                    <RedoOutlined />
+                return (<Button key={2} size="sm" variant="outlined" style={{borderWidth: props.backupsEnabled ? '' : '0px'}} onClick={props.handleUndo} disabled={!props.backupsEnabled}>
+                    <UndoOutlined />
                 </Button>)
             }
         },
         3: {
-            label: "Center on molecule",
-            compressed: () => { return (<MenuItem key={3} variant="success" onClick={props.handleCentering}>Center on molecule</MenuItem>) },
+            label: "Redo previous action",
+            compressed: () => { return (<MenuItem key={3} variant="success" onClick={props.handleRedo} disabled={!props.backupsEnabled}>Redo previous action</MenuItem>) },
             expanded: () => {
-                return (<Button key={3} size="sm" variant="outlined" onClick={props.handleCentering}>
-                    <CenterFocusWeakOutlined />
+                return (<Button key={3} size="sm" variant="outlined" style={{borderWidth: props.backupsEnabled ? '': '0px'}} onClick={props.handleRedo} disabled={!props.backupsEnabled}>
+                    <RedoOutlined />
                 </Button>)
             }
         },
         4: {
-            label: props.isVisible ? "Hide molecule" : "Show molecule",
-            compressed: () => { return (<MenuItem key={4} variant="success" onClick={props.handleVisibility}>{props.isVisible ? "Hide molecule" : "Show molecule"}</MenuItem>) },
+            label: "Center on molecule",
+            compressed: () => { return (<MenuItem key={4} variant="success" onClick={props.handleCentering}>Center on molecule</MenuItem>) },
             expanded: () => {
-                return (<Button key={4} size="sm" variant="outlined" onClick={props.handleVisibility}>
-                    {props.isVisible ? <VisibilityOffOutlined /> : <VisibilityOutlined />}
+                return (<Button key={4} size="sm" variant="outlined" onClick={props.handleCentering}>
+                    <CenterFocusWeakOutlined />
                 </Button>)
             }
         },
@@ -102,7 +102,7 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
         },
     }
 
-    const maximumAllowedWidth = props.sideBarWidth * 0.35
+    const maximumAllowedWidth = props.sideBarWidth * 0.55
     let currentlyUsedWidth = 0
     let expandedButtons = []
     let compressedButtons = []

--- a/baby-gru/src/components/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/MoorhenPreferencesMenu.js
@@ -16,9 +16,9 @@ export const MoorhenPreferencesMenu = (props) => {
         showShortcutToast, setShowShortcutToast, defaultMapSurface, setDefaultMapSurface,
         defaultBondSmoothness, setDefaultBondSmoothness, showScoresToast, setShowScoresToast,
         defaultUpdatingScores, setDefaultUpdatingScores, drawFPS, setDrawFPS, wheelSensitivityFactor,
-        setWheelSensitivityFactor, shortcutOnHoveredAtom, setShortcutOnHoveredAtom, resetClippingFogging, 
-        setResetClippingFogging, maxBackupCount, setMaxBackupCount, modificationCountBackupThreshold,
-        setModificationCountBackupThreshold, timeCapsuleRef
+        setWheelSensitivityFactor, shortcutOnHoveredAtom, setShortcutOnHoveredAtom, maxBackupCount, 
+        setMaxBackupCount, modificationCountBackupThreshold, setModificationCountBackupThreshold, 
+        timeCapsuleRef
      } = props;
 
     const [showModal, setShowModal] = useState(null);
@@ -130,13 +130,6 @@ export const MoorhenPreferencesMenu = (props) => {
                             checked={shortcutOnHoveredAtom}
                             onChange={() => { setShortcutOnHoveredAtom(!shortcutOnHoveredAtom) }}
                             label="Hover on residue to use shortcuts"/>
-                    </InputGroup>
-                    <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
-                        <Form.Check 
-                            type="switch"
-                            checked={resetClippingFogging}
-                            onChange={() => { setResetClippingFogging(!resetClippingFogging) }}
-                            label="Reset clipping and fogging on zoom"/>
                     </InputGroup>
                     <MoorhenBackupPreferencesMenuItem 
                         maxBackupCount={maxBackupCount}

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -6,7 +6,6 @@ import { convertViewtoPx } from '../utils/MoorhenUtils.js';
 
 export const MoorhenWebMG = forwardRef((props, glRef) => {
     const scores = useRef({})
-    const windowResizedBinding = createRef(null)
     const [mapLineWidth, setMapLineWidth] = useState(1.0)
     const [connectedMolNo, setConnectedMolNo] = useState(null)
     const [scoresToastContents, setScoreToastContents] = useState(null)
@@ -228,19 +227,24 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
     }, [handleMiddleClickGoToAtom]);
 
+    const handleWindowResized = useCallback((e) => {
+        glRef.current.resize(props.width(), props.height())
+        glRef.current.drawScene()
+    }, [glRef, props.width, props.height])
+
     useEffect(() => {
         glRef.current.setAmbientLightNoUpdate(0.2, 0.2, 0.2);
         glRef.current.setSpecularLightNoUpdate(0.6, 0.6, 0.6);
         glRef.current.setDiffuseLight(1., 1., 1.);
         glRef.current.setLightPositionNoUpdate(10., 10., 60.);
         setClipFogByZoom()
-        windowResizedBinding.current = window.addEventListener('resize', windowResized)
-        windowResized()
+        window.addEventListener('resize', handleWindowResized)
+        handleWindowResized()
         glRef.current.drawScene()
         return () => {
-            window.removeEventListener('resize', windowResizedBinding.current)
+            window.removeEventListener('resize', handleWindowResized)
         }
-    }, [glRef])
+    }, [handleWindowResized])
 
     useEffect(() => {
         if (glRef.current) {
@@ -292,11 +296,6 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             }
         })
     }, [props.maps, props.maps.length])
-
-    const windowResized = (e) => {
-        glRef.current.resize(props.width(), props.height())
-        glRef.current.drawScene()
-    }
 
     return  <>
                 <ToastContainer style={{ zIndex: '0', marginTop: "5rem", marginLeft: '0.5rem', textAlign:'left', alignItems: 'left', maxWidth: convertViewtoPx(40, props.windowWidth)}} position='top-start' >

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -1,5 +1,5 @@
-
-
+import { OverlayTrigger } from "react-bootstrap";
+import { Tooltip } from "@mui/material";
 import { v4 as uuidv4 } from 'uuid';
 
 export function guid(){
@@ -587,4 +587,32 @@ export const getMultiColourRuleArgs = (molecule, ruleType) => {
     }
 
     return multiRulesArgs
+}
+
+export const getNameLabel = (item) => {
+    if (item.name.length > 9) {
+        return <OverlayTrigger
+                key={item.molNo}
+                id="name-label-trigger"
+                placement="top"
+                overlay={
+                    <Tooltip id="name-label-tooltip" 
+                    style={{
+                        backgroundColor: 'rgba(0, 0, 0, 0.85)',
+                        padding: '2px 10px',
+                        color: 'white',
+                        borderRadius: 3,
+                    }}>
+                        <div>
+                            {item.name}
+                        </div>
+                    </Tooltip>
+                }
+                >
+                <div>
+                    {`#${item.molNo} Mol. ${item.name.slice(0,4)}...`}
+                </div>
+                </OverlayTrigger>
+    }
+    return `#${item.molNo} Mol. ${item.name}`
 }


### PR DESCRIPTION
This update includes:
- Fixed an issue with a window resize event listener
- Molecule and map names are omitted if they are longer than 10 characters. There's a tooltip that will appear on hover to show the full name
- Switched order of molecule card buttons as requested
- Moved switch to reset clipping/fogging on zoom to the VIew > Clipping/Fogging menu item