### PR TITLE
Enable two click mode for rigid body fit and enable random jiggle fit

### DIFF
--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -340,6 +340,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<>()
+    .function("fit_to_map_by_random_jiggle_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_using_cid)
     .function("get_active_atom",&molecules_container_t::get_active_atom)
     .function("is_a_difference_map",&molecules_container_t::is_a_difference_map)
     .function("add_hydrogen_atoms",&molecules_container_t::add_hydrogen_atoms)


### PR DESCRIPTION
This update includes:
- Random jiggle fit is added as a switch in the rigid body fit button
- Code in `MoorhenSimpleEditButton` has been extensively refactored to accommodate a new two click mode which can be used to define a residue range in the rigid body fit button