### PR TITLE
Add selection style to molecule

### DIFF
--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -391,7 +391,7 @@ export const MoorhenMoleculeCard = (props) => {
                 "#CCC"}}>
                         <FormGroup style={{ margin: "0px", padding: "0px" }} row>
                             {Object.keys(props.molecule.displayObjects)
-                                .filter(key => !['hover', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
+                                .filter(key => !['hover', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
                                 .map(key => getCheckBox(key))}
                         </FormGroup>
                     </div>

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -419,7 +419,7 @@ export const cidToSpec = (cid) => {
     const atom_name = cidTokens[4].split(":")[0]
     const ins_code = cidTokens[3].split(".").length > 1 ? cidTokens[3].split(".")[1] : ""
     const alt_conf = cidTokens[4].split(":").length > 1 ? cidTokens[4].split(":")[1] : ""
-    return { chain_id, res_no, atom_name, ins_code, alt_conf }
+    return { chain_id, res_no, atom_name, ins_code, alt_conf, cid }
 }
 
 export const getResidueInfo = (molecules, selectedMolNo, selectedChain, selectedResidueIndex) => {


### PR DESCRIPTION
This adds a selection style to `MoorhenMolecule`. Currently this is used to indicate what is the first residue selected for rigid body fitting.