### PR TITLE
Store reflection data in session backup

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.js
+++ b/baby-gru/public/baby-gru/CootWorker.js
@@ -534,14 +534,10 @@ const associate_data_mtz_file_with_map = (iMol, mtzData, F, SIGF, FREE) => {
     const theGuid = guid()
     const asUint8Array = new Uint8Array(mtzData.data)
     cootModule.FS_createDataFile(".", `${theGuid}.mtz`, asUint8Array, true, true);
-    const tempFilename = `./${theGuid}.mtz`
-    /*associate_data_mtz_file_with_map(int imol, const std::string &data_mtz_file_name,
-        const std::string &f_col, const std::string &sigf_col,
-        const std::string &free_r_col);
-        */
-    const args = [iMol, tempFilename, F, SIGF, FREE]
-
-    return molecules_container.associate_data_mtz_file_with_map(...args)
+    const mtzFilename = `./${theGuid}.mtz`
+    const args = [iMol, mtzFilename, F, SIGF, FREE]
+    molecules_container.associate_data_mtz_file_with_map(...args)
+    return mtzFilename
 }
 
 const read_ccp4_map = (mapData, name, isDiffMap) => {
@@ -611,6 +607,17 @@ onmessage = function (e) {
             consoleMessage: `Fetched coordinates of molecule ${e.data.molNo}`,
             message: e.data.message,
             result: { molNo: e.data.molNo, pdbData: pdbData }
+        })
+    }
+
+    else if (e.data.message === 'get_mtz_data') {
+        const mtzData = cootModule.FS.readFile(e.data.fileName, { encoding: 'binary' });
+        postMessage({
+            messageId: e.data.messageId,
+            myTimeStamp: e.data.myTimeStamp,
+            consoleMessage: `Fetched mtz data for map ${e.data.molNo}`,
+            message: e.data.message,
+            result: { molNo: e.data.molNo, mtzData: mtzData }
         })
     }
 
@@ -685,6 +692,17 @@ onmessage = function (e) {
 
     else if (e.data.message === 'delete') {
         const result = molecules_container.close_molecule(e.data.molNo)
+
+        postMessage({
+            messageId: e.data.messageId,
+            myTimeStamp: e.data.myTimeStamp,
+            messageTag: "result",
+            result: result,
+        })
+    }
+
+    else if (e.data.message === 'delete_file_name') {
+        const result = cootModule.FS_unlink(e.data.fileName)
 
         postMessage({
             messageId: e.data.messageId,

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -37,6 +37,8 @@ export const MoorhenContainer = (props) => {
     const timeCapsuleRef = useRef(null)
     const commandCentre = useRef(null)
     const moleculesRef = useRef(null)
+    const mapsRef = useRef(null)
+    const activeMapRef = useRef(null)
     const consoleDivRef = useRef(null)
     const lastHoveredAtom = useRef(null)
     const preferences = useContext(PreferencesContext);
@@ -61,6 +63,8 @@ export const MoorhenContainer = (props) => {
     const [showColourRulesToast, setShowColourRulesToast] = useState(false)
     
     moleculesRef.current = molecules
+    mapsRef.current = maps
+    activeMapRef.current = activeMap
     const innerWindowMarginHeight = convertRemToPx(0.5)
     const innerWindowMarginWidth = convertRemToPx(1)
 
@@ -74,7 +78,7 @@ export const MoorhenContainer = (props) => {
     useEffect(() => {
         if (cootInitialized && props.forwardControls) {
             props.forwardControls(collectedProps)
-            timeCapsuleRef.current = new MoorhenTimeCapsule(moleculesRef, glRef, preferences)
+            timeCapsuleRef.current = new MoorhenTimeCapsule(moleculesRef, mapsRef, activeMapRef, glRef, preferences)
             timeCapsuleRef.current.maxBackupCount = preferences.maxBackupCount
             timeCapsuleRef.current.modificationCountBackupThreshold = preferences.modificationCountBackupThreshold
         }

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -231,7 +231,7 @@ export const MoorhenFileMenu = (props) => {
         })
 
         // Set active map
-        if (typeof sessionData.activeMapIndex !== -1){
+        if (sessionData.activeMapIndex !== -1){
             props.setActiveMap(newMaps[sessionData.activeMapIndex])
         }
 

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -456,6 +456,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("SSM_superpose",&molecules_container_t::SSM_superpose)
     .function("add_to_non_drawn_bonds",&molecules_container_t::add_to_non_drawn_bonds)
     .function("clear_non_drawn_bonds",&molecules_container_t::clear_non_drawn_bonds)
+    .function("file_name_to_string",&molecules_container_t::file_name_to_string)
     ;
     class_<molecules_container_js, base<molecules_container_t>>("molecules_container_js")
     .constructor<>()


### PR DESCRIPTION
After this update, reflection data associated with a given map is also stored in the session backup. This means map can be re-connected after loading a backup.