### PR TITLE
Store unique mtz string in local storage

### DIFF
--- a/baby-gru/src/components/MoorhenNavBar.js
+++ b/baby-gru/src/components/MoorhenNavBar.js
@@ -1,4 +1,4 @@
-import { forwardRef, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { Navbar, Nav,  Spinner, Form } from 'react-bootstrap';
 import { MoorhenFileMenu } from './MoorhenFileMenu';
 import { MoorhenPreferencesMenu } from './MoorhenPreferencesMenu';
@@ -7,9 +7,17 @@ import { MoorhenViewMenu } from './MoorhenViewMenu';
 import { MoorhenLigandMenu } from './MoorhenLigandMenu';
 import { MoorhenEditMenu } from './MoorhenEditMenu';
 import { MoorhenHelpMenu } from './MoorhenHelpMenu';
+import { SaveOutlined } from '@mui/icons-material';
 
 export const MoorhenNavBar = forwardRef((props, ref) => {
     const [currentDropdownId, setCurrentDropdownId] = useState(-1)
+    const [showSaveIcon, setShowSaveIcon] = useState(false)
+
+    useEffect(() => {
+        if (props.timeCapsuleRef.current) {
+            setShowSaveIcon(props.timeCapsuleRef.current.busy)
+        }
+    }, [props.timeCapsuleRef.current?.busy])
 
     const collectedProps = {currentDropdownId, setCurrentDropdownId, ...props}
 
@@ -30,6 +38,7 @@ export const MoorhenNavBar = forwardRef((props, ref) => {
                 <Nav className="justify-content-right">
                     {props.hoveredAtom.cid && <Form.Control style={{ height: '2rem', width: "20rem" }} type="text" readOnly={true} value={`${props.hoveredAtom.molecule.name}:${props.hoveredAtom.cid}`} />}
                     {props.busy && <Spinner animation="border" style={{ height: '2rem', marginRight: '0.5rem', marginLeft: '0.5rem' }} />}
+                    {showSaveIcon && <SaveOutlined style={{padding: 0, margin: 0}}/>}
                 </Nav>
             </Navbar>
 })


### PR DESCRIPTION
After this update, strings with MTZ file contents will be stored under the same entry in local storage, reducing the memory consumed by backups.