### PR TITLE
Show shortcut help as HUD instead of a toast

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.js
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.js
@@ -1361,6 +1361,7 @@ class MGWebGL extends Component {
         this.nPrevFrames = 0;
         this.prevTime = performance.now();
         this.fpsText = "";
+        this.showShortCutHelp = null;
 
         const frameCounterTimer = setInterval(() => {
             if(!self.context) return;
@@ -10009,7 +10010,16 @@ class MGWebGL extends Component {
                 let ypos = label.y * 48.0 -24.;
                 drawString(label.text,xpos,ypos, label.font);
         });
-        if(this.showFPS) drawString(this.fpsText,-23.5*ratio,-23.5,"20px helvetica");
+        if(this.showFPS) drawString(this.fpsText, -23.5*ratio, -23.5, "20px helvetica");
+        if(this.showShortCutHelp) {
+            const fontSize = this.gl.viewportHeight * 0.02
+            const font = `${fontSize > 20 ? 20 : fontSize}px helvetica`
+            this.showShortCutHelp.forEach((shortcut, index) => {
+                const xpos = -23.5 * ratio
+                const ypos = 20 - index
+                drawString(shortcut, xpos, ypos, font)
+            });
+        }
 
         this.gl.disableVertexAttribArray(this.shaderProgramTextBackground.vertexTextureAttribute);
         this.gl.depthFunc(this.gl.LESS)

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -416,18 +416,21 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     }
 
     else if (action === 'show_shortcuts') {
-        setToastContent(<h4><List>
-            {Object.keys(shortCuts).map(key => {
+        if (!glRef.current.showShortCutHelp) {
+            glRef.current.showShortCutHelp = Object.keys(shortCuts).map(key => {
                 let modifiers = []
                 if (shortCuts[key].modifiers.includes('shiftKey')) modifiers.push("<Shift>")
                 if (shortCuts[key].modifiers.includes('ctrlKey')) modifiers.push("<Ctrl>")
                 if (shortCuts[key].modifiers.includes('metaKey')) modifiers.push("<Meta>")
                 if (shortCuts[key].modifiers.includes('altKey')) modifiers.push("<Alt>")
                 if (shortCuts[key].keyPress === " ") modifiers.push("<Space>")
-                return <ListItem>{`${modifiers.join("-")} ${shortCuts[key].keyPress} ${shortCuts[key].label}`}</ListItem>
-            })}
-        </List></h4>)
-        setShowToast(true)
+                return `${modifiers.join("-")} ${shortCuts[key].keyPress} ${shortCuts[key].label}`
+            })
+            glRef.current.drawScene()    
+        } else  {
+            glRef.current.showShortCutHelp = null
+            glRef.current.drawScene()
+        }
         return false
     }
 

--- a/baby-gru/src/components/MoorhenNavBar.js
+++ b/baby-gru/src/components/MoorhenNavBar.js
@@ -24,7 +24,8 @@ export const MoorhenNavBar = forwardRef((props, ref) => {
     return  <Navbar ref={ref} id='navbar-baby-gru' className={props.isDark ? "navbar-dark" : "navbar-light"} style={{ borderBottom: '1px solid grey', height: '2rem', justifyContent: 'between', margin: '0.1rem', padding: '0.1rem' }}>
                 <Navbar.Toggle aria-controls="basic-navbar-nav" />
                 <Navbar.Collapse id="basic-navbar-nav">
-                    <Nav className="justify-content-left">
+                    <Nav className="justify-content-left" style={{verticalAlign: 'center', alignItems:'center', alignContent:'center'}}>
+                        <img src={`${props.urlPrefix}/baby-gru/pixmaps/MoorhenLogo.png`} alt='Moorhen' style={{height: '1.6rem', marginRight: '0.3rem'}}/>
                         <MoorhenFileMenu dropdownId="File" {...collectedProps} />
                         <MoorhenEditMenu dropdownId="Edit" {...collectedProps} />
                         <MoorhenLigandMenu dropdownId="Ligand" {...collectedProps} />

--- a/baby-gru/src/components/MoorhenNavBar.js
+++ b/baby-gru/src/components/MoorhenNavBar.js
@@ -25,7 +25,7 @@ export const MoorhenNavBar = forwardRef((props, ref) => {
                 <Navbar.Toggle aria-controls="basic-navbar-nav" />
                 <Navbar.Collapse id="basic-navbar-nav">
                     <Nav className="justify-content-left" style={{verticalAlign: 'center', alignItems:'center', alignContent:'center'}}>
-                        <img src={`${props.urlPrefix}/baby-gru/pixmaps/MoorhenLogo.png`} alt='Moorhen' style={{height: '1.6rem', marginRight: '0.3rem'}}/>
+                        {props.windowWidth >= 1000 ? <img src={`${props.urlPrefix}/baby-gru/pixmaps/MoorhenLogo.png`} alt='Moorhen' style={{height: '1.6rem', marginRight: '0.3rem'}}/> : null}
                         <MoorhenFileMenu dropdownId="File" {...collectedProps} />
                         <MoorhenEditMenu dropdownId="Edit" {...collectedProps} />
                         <MoorhenLigandMenu dropdownId="Ligand" {...collectedProps} />

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -83,7 +83,7 @@ const getDefaultValues = () => {
             },
             "show_shortcuts": {
                 modifiers: [],
-                keyPress: "escape",
+                keyPress: "h",
                 label: "Show shortcuts"
             },
             "restore_scene": {


### PR DESCRIPTION
This moves the shortcut help into HUD text that can be toggled on/off instead of a toast that disappears after a few seconds. Also the bird is back.