### PR TITLE
Set bond colours following colour rules of other representations

### DIFF
--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -426,11 +426,19 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
                 if (shortCuts[key].keyPress === " ") modifiers.push("<Space>")
                 return `${modifiers.join("-")} ${shortCuts[key].keyPress} ${shortCuts[key].label}`
             })
-            glRef.current.drawScene()    
+            glRef.current.drawScene()
         } else  {
             glRef.current.showShortCutHelp = null
             glRef.current.drawScene()
         }
+        setToastContent(
+            <h3>
+                <List>
+                    <ListItem style={{justifyContent: 'center'}}>{`${modifiers.join("-")} ${event.key} pushed`}</ListItem>
+                    <ListItem style={{justifyContent: 'center'}}>{glRef.current.showShortCutHelp ? 'Show help' : 'Hide help'}</ListItem>
+                </List>
+            </h3>
+        )
         return false
     }
 

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -1,6 +1,7 @@
 import { OverlayTrigger } from "react-bootstrap";
 import { Tooltip } from "@mui/material";
 import { v4 as uuidv4 } from 'uuid';
+import { hexToRgb } from "@mui/material";
 
 export function guid(){
     var d = Date.now();
@@ -614,3 +615,32 @@ export const getNameLabel = (item) => {
     }
     return `#${item.molNo} Mol. ${item.name}`
 }
+
+export const hexToHsl = (hex) => {
+    let [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ')
+    r /= 255;
+    g /= 255;
+    b /= 255;
+
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h, s, l = (max + min) / 2;
+  
+    if (max === min) {
+      h = s = 0;
+    } else {
+      const d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  
+      switch (max) {
+        case r: h = (g - b) / d + (g < b ? 6 : 0); break;
+        case g: h = (b - r) / d + 2; break;
+        case b: h = (r - g) / d + 4; break;
+        default: break;
+      }
+  
+      h /= 6;
+    }
+  
+    return [ h, s, l ];
+  }

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -340,6 +340,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<>()
+    .function("set_colour_wheel_rotation_base",&molecules_container_t::set_colour_wheel_rotation_base)
     .function("fit_to_map_by_random_jiggle_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_using_cid)
     .function("get_active_atom",&molecules_container_t::get_active_atom)
     .function("is_a_difference_map",&molecules_container_t::is_a_difference_map)


### PR DESCRIPTION
After this update bond colours are set so that they follow the colour rules used for other representations. At the moment this is only implemented with colour rules affecting the whole molecule.