### PR TITLE
Fix molecule representation checkbox bug

### DIFF
--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -209,7 +209,7 @@ export const MoorhenMoleculeCard = (props) => {
         Object.keys(props.molecule.displayObjects).forEach(key => {
             const displayObjects = props.molecule.displayObjects[key]
             changeShowState({
-                key: key, state: displayObjects.length > 0 && displayObjects.visible
+                key: key, state: displayObjects.length > 0 && displayObjects[0].visible
             })
         })
     }, [


### PR DESCRIPTION
This update fixes the bug where the initial state of molecule representation checkboxes is not set properly (bonds are not checked).