### PR TITLE
Updates and bug fixes for time capsule

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.js
+++ b/baby-gru/public/baby-gru/CootWorker.js
@@ -541,10 +541,9 @@ const read_mtz = (mapData, name, selectedColumns) => {
 }
 
 const associate_data_mtz_file_with_map = (iMol, mtzData, F, SIGF, FREE) => {
-    const theGuid = guid()
     const asUint8Array = new Uint8Array(mtzData.data)
-    cootModule.FS_createDataFile(".", `${theGuid}.mtz`, asUint8Array, true, true);
-    const mtzFilename = `./${theGuid}.mtz`
+    cootModule.FS_createDataFile(".", `${mtzData.fileName}.mtz`, asUint8Array, true, true);
+    const mtzFilename = `./${mtzData.fileName}.mtz`
     const args = [iMol, mtzFilename, F, SIGF, FREE]
     molecules_container.associate_data_mtz_file_with_map(...args)
     return mtzFilename
@@ -603,7 +602,7 @@ onmessage = function (e) {
                 print(e);
             });
     }
-
+    
     else if (e.data.message === 'get_atoms') {
         const theGuid = guid()
         const tempFilename = `./${theGuid}.pdb`

--- a/baby-gru/src/utils/MoorhenMap.js
+++ b/baby-gru/src/utils/MoorhenMap.js
@@ -1,4 +1,4 @@
-import { readDataFile } from "./MoorhenUtils"
+import { readDataFile, guid } from "./MoorhenUtils"
 import { readMapFromArrayBuffer, mapToMapGrid } from '../WebGLgComponents/mgWebGLReadMap';
 
 export function MoorhenMap(commandCentre) {
@@ -18,6 +18,7 @@ export function MoorhenMap(commandCentre) {
     this.hasReflectionData = false
     this.selectedColumns = null
     this.associatedReflectionFileName = null
+    this.uniqueId = guid()
 }
 
 MoorhenMap.prototype.delete = async function (glRef) {
@@ -306,7 +307,7 @@ MoorhenMap.prototype.associateToReflectionData = async function (selectedColumns
     }
     
     const commandArgs = [
-        this.molNo, { name: this.name, data: reflectionData },
+        this.molNo, { fileName: this.uniqueId, data: reflectionData },
         selectedColumns.Fobs, selectedColumns.SigFobs, selectedColumns.FreeR
     ]
 

--- a/baby-gru/src/utils/MoorhenTimeCapsule.js
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.js
@@ -38,7 +38,7 @@ MoorhenTimeCapsule.prototype.checkVersion = async function () {
 
 MoorhenTimeCapsule.prototype.updateMtzFiles = async function () {
     const allKeyStrings = await this.storageInstance.keys()
-    const currentMtzFiles = allKeyStrings.map(keyString => JSON.parse(keyString)).filter(key => key.type === 'mtzData')
+    const currentMtzFiles = allKeyStrings.map(keyString => JSON.parse(keyString)).filter(key => key.type === 'mtzData').map(key => key.name)
     return Promise.all(
         this.mapsRef.current.map(async (map) => {
             const fileName = map.associatedReflectionFileName


### PR DESCRIPTION
This update includes:
- Similarly to what happens already with the reflection data, map data is only stored once in the local storage backups. This way backups for big EM maps will not use so much space
- A fix for a bug that was causing the creation of repeated mtz file entries in the local storage backups unexpectedly
- Fix bug where creating and loading backups repeatedly could cause unnecessary mtz entries being created in the local storage and stored forever