### PR TITLE
Make moorhen more GUI agnostic

### DIFF
--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -14,7 +14,7 @@ export default class MoorhenWrapper {
     this.urlPrefix = urlPrefix
     this.controls = null
     this.monomerLibrary = null
-    this.exportToCloudCallback = () => {}
+    this.exportCallback = () => {}
     reportWebVitals()
   }
 
@@ -67,7 +67,7 @@ export default class MoorhenWrapper {
   }
 
   addOnExportListener(callbackFunction){
-    this.exportToCloudCallback = callbackFunction
+    this.exportCallback = callbackFunction
   }
 
   addMonomerLibrary(monomerLibrary){
@@ -160,8 +160,8 @@ export default class MoorhenWrapper {
           <PreferencesContextProvider>
             <MoorhenContainer 
               forwardControls={this.forwardControls.bind(this)}
-              isCloud={true}
-              exportToCloudCallback={this.exportToCloudCallback.bind(this)}
+              disableFileUploads={true}
+              exportCallback={this.exportCallback.bind(this)}
               monomerLibrary={this.monomerLibrary}
               />
           </PreferencesContextProvider>

--- a/baby-gru/cloud/index.html
+++ b/baby-gru/cloud/index.html
@@ -60,7 +60,7 @@ main UI thread (as opposed to the CootWorker)-->
   <script type="text/javascript" defer>
     const rootId = "root"
     const  urlPrefix = "."
-    const exportToCloudCallback = (molName, molData) => {console.log({name: molName, data: molData})}
+    const exportCallback = (molName, molData) => {console.log({name: molName, data: molData})}
     const inputFiles = [
       {type: 'pdb', args: ["./baby-gru/tutorials/moorhen-tutorial-structure-number-1.pdb", "molecule"]},
       {type: 'mtz', args: [
@@ -221,9 +221,9 @@ main UI thread (as opposed to the CootWorker)-->
 
     async function startMoorhen() {
       let moorhenWrapper = new moorhen.MoorhenWrapper(urlPrefix)
-      moorhenWrapper.addOnExportListener(exportToCloudCallback)
+      moorhenWrapper.addOnExportListener(exportCallback)
       await moorhenWrapper.importPreferences(userPreferences)
-      moorhenWrapper.renderMoorhen(rootId, exportToCloudCallback)
+      moorhenWrapper.renderMoorhen(rootId, exportCallback)
       await moorhenWrapper.waitForInitialisation()
       await moorhenWrapper.loadInputFiles(inputFiles)
       setTimeout(() => {moorhenWrapper.exportBackups()}, 6000);

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -280,7 +280,7 @@ export const MoorhenContainer = (props) => {
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, toastContent, 
         setToastContent, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, showToast, setShowToast,
         windowWidth, windowHeight, innerWindowMarginWidth, showColourRulesToast, timeCapsuleRef, setShowColourRulesToast, 
-        isDark, exportToCloudCallback: props.exportToCloudCallback, isCloud: props.isCloud, urlPrefix: props.urlPrefix, 
+        isDark, exportCallback: props.exportCallback, disableFileUploads: props.disableFileUploads, urlPrefix: props.urlPrefix, 
         extraMenus:props.extraMenus, ...preferences
     }
 
@@ -347,7 +347,7 @@ export const MoorhenContainer = (props) => {
 
 MoorhenContainer.defaultProps = {
     urlPrefix: '.',
-    exportToCloudCallback: null,
-    isCloud: false,
+    exportCallback: null,
+    disableFileUploads: false,
     extraMenus:[]
 }

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -453,7 +453,7 @@ export const MoorhenFileMenu = (props) => {
                     
                     <MoorhenBackupsMenuItem {...menuItemProps} setShowBackupsModal={setShowBackupsModal} loadSessionJSON={loadSessionJSON} />
 
-                    {props.disableFileUploads &&
+                    {props.exportCallback &&
                         <MenuItem id='cloud-export-menu-item' variant="success" onClick={doExportCallback}>
                             Export to CCP4 Cloud
                         </MenuItem>

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -46,10 +46,10 @@ export const MoorhenFileMenu = (props) => {
         return newMolecule.loadToCootFromFile(file)
     }
 
-    const exportToCloud = async () => {
+    const doExportCallback = async () => {
         let moleculePromises = props.molecules.map(molecule => {return molecule.getAtoms()})
         let moleculeAtoms = await Promise.all(moleculePromises)
-        props.molecules.forEach((molecule, index) => props.exportToCloudCallback(molecule.name, moleculeAtoms[index].data.result.pdbData))
+        props.molecules.forEach((molecule, index) => props.exportCallback(molecule.name, moleculeAtoms[index].data.result.pdbData))
     }
 
     const fetchFiles = () => {
@@ -390,7 +390,7 @@ export const MoorhenFileMenu = (props) => {
             style={{display:'flex', alignItems:'center'}}
             onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
                 <div style={{maxHeight: convertViewtoPx(65, props.windowHeight), overflowY: 'auto'}}>
-                    {!props.isCloud && 
+                    {!props.disableFileUploads && 
                     <Form.Group style={{ width: '20rem', margin: '0.5rem' }} controlId="upload-coordinates-form" className="mb-3">
                         <Form.Label>Coordinates</Form.Label>
                         <Form.Control type="file" accept=".pdb, .mmcif, .cif, .ent" multiple={true} onChange={(e) => { loadPdbFiles(e.target.files) }}/>
@@ -423,7 +423,7 @@ export const MoorhenFileMenu = (props) => {
                         <Form.Label style={{display: isValidPdbId ? 'none' : 'block', alignContent: 'center' ,textAlign: 'center'}}>Problem fetching</Form.Label>
                         <Form.Check style={{ marginTop: '0.5rem' }} ref={fetchMapDataCheckRef} label={'fetch map data'} name={`fetchMapData`} type="checkbox" variant="outline" />
                     </Form.Group>
-                    {!props.isCloud && 
+                    {!props.disableFileUploads && 
                     <Form.Group style={{ width: '20rem', margin: '0.5rem' }} controlId="upload-session-form" className="mb-3">
                         <Form.Label>Load from stored session</Form.Label>
                         <Form.Control type="file" accept=".json" multiple={false} onChange={(e) => { loadSession(e.target.files[0]) }}/>
@@ -431,7 +431,7 @@ export const MoorhenFileMenu = (props) => {
                     }
                     <hr></hr>
 
-                    {!props.isCloud && 
+                    {!props.disableFileUploads && 
                     <>
                         <MoorhenAutoOpenMtzMenuItem {...menuItemProps} />
                         <MoorhenImportMapCoefficientsMenuItem {...menuItemProps} />
@@ -453,8 +453,8 @@ export const MoorhenFileMenu = (props) => {
                     
                     <MoorhenBackupsMenuItem {...menuItemProps} setShowBackupsModal={setShowBackupsModal} loadSessionJSON={loadSessionJSON} />
 
-                    {props.isCloud &&
-                        <MenuItem id='cloud-export-menu-item' variant="success" onClick={exportToCloud}>
+                    {props.disableFileUploads &&
+                        <MenuItem id='cloud-export-menu-item' variant="success" onClick={doExportCallback}>
                             Export to CCP4 Cloud
                         </MenuItem>
                     }


### PR DESCRIPTION
Renamed `props.isCloud` to `props.disableFileUploads` and `props.exportToCloudCallback` to `props.exportCallback`. Function `exportToCloud` inside `MoorhenFileMenu.js` also renamed to `doExportCallback` which calls `props.exportCallback` if it has been provided. All of this infrastructure would then be available for other GUIs that might want to make use of it.