### PR TITLE
Implement full set of edit buttons in the context menu

### DIFF
--- a/baby-gru/src/components/MoorhenContextMenu.js
+++ b/baby-gru/src/components/MoorhenContextMenu.js
@@ -1,7 +1,9 @@
 import styled, { css } from "styled-components";
-import { ClickAwayListener, FormGroup, IconButton, List, MenuItem } from '@mui/material';
+import { ClickAwayListener, FormGroup, IconButton, List, MenuItem, Tooltip } from '@mui/material';
 import { MoorhenMergeMoleculesMenuItem, MoorhenGetMonomerMenuItem, MoorhenFitLigandRightHereMenuItem, MoorhenImportFSigFMenuItem } from "./MoorhenMenuItem";
-import { cidToSpec } from "../utils/MoorhenUtils";
+import { cidToSpec, convertViewtoPx, getTooltipShortcutLabel } from "../utils/MoorhenUtils";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { Button, Overlay } from "react-bootstrap"
 
 const ContextMenu = styled.div`
   position: absolute;
@@ -19,6 +21,21 @@ const ContextMenu = styled.div`
 `;
 
 const MoorhenContextQuickEditButton = (props) => {
+  const target = useRef(null)
+  const [prompt, setPrompt] = useState(null)
+  const [localParameters, setLocalParameters] = useState({})
+
+  useEffect(() => {
+      setPrompt(props.prompt)
+  }, [props.prompt])
+
+  useEffect(() => {
+      setLocalParameters(props.panelParameters)
+  }, [])
+
+  useEffect(() => {
+      setLocalParameters(props.panelParameters)
+  }, [props.panelParameters])
 
   const handleClick = async () => {
     const cootResult = await props.commandCentre.current.cootCommand(props.cootCommandInput)
@@ -52,13 +69,17 @@ const MoorhenContextQuickEditButton = (props) => {
     props.setShowContextMenu(false)
   }
 
-  return  <IconButton 
-            onClick={handleClick}
-            style={{width:'2rem', height: '2rem', margin: 0, paddingRight: 0, paddingTop: 0, paddingBottom: 0, paddingLeft: '0.1rem'}}
-            disabled={props.needsMapData && !props.activeMap || (props.needsAtomData && props.molecules.length === 0)}
-          >
-            {props.icon}
-          </IconButton>
+  return <>
+          <Tooltip title={(props.needsMapData && !props.activeMap) || (props.needsAtomData && props.molecules.length === 0) ? '' : props.toolTip}>
+              <IconButton 
+                onClick={handleClick}
+                style={{width:'2rem', height: '2rem', margin: 0, paddingRight: 0, paddingTop: 0, paddingBottom: 0, paddingLeft: '0.1rem'}}
+                disabled={props.needsMapData && !props.activeMap || (props.needsAtomData && props.molecules.length === 0)}
+              >
+                {props.icon}
+              </IconButton>
+          </Tooltip>
+        </>
 }
 
 MoorhenContextQuickEditButton.defaultProps = {
@@ -121,6 +142,7 @@ export const MoorhenContextMenu = (props) => {
                      <hr></hr>
                      <FormGroup style={{ margin: "0px", padding: "0px", width: '20rem' }} row>
                       <MoorhenContextQuickEditButton 
+                          toolTip={props.shortCuts ? `Auto-fit Rotamer ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).auto_fit_rotamer)}` : "Auto-fit Rotamer"}
                           icon={<img style={{width:'100%', height: '100%'}} src={`${props.urlPrefix}/baby-gru/pixmaps/auto-fit-rotamer.svg`} alt='Auto-Fit rotamer'/>}
                           needsMapData={true}
                           selectedMolecule={selectedMolecule}
@@ -139,6 +161,7 @@ export const MoorhenContextMenu = (props) => {
                           needsMapData={true}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
+                          toolTip={props.shortCuts ? `Flip Peptide ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).flip_peptide)}` : "Flip Peptide"}
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -152,6 +175,7 @@ export const MoorhenContextMenu = (props) => {
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/side-chain-180.svg`} alt='Rotate Side-chain'/>}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
+                          toolTip="Rotate side-chain 180 degrees"
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -167,6 +191,7 @@ export const MoorhenContextMenu = (props) => {
                           chosenAtom={chosenAtom}
                           needsMapData={true}
                           refineAfterMod={false}
+                          toolTip={props.shortCuts ? `Refine Residues ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).triple_refine)}` : "Refine Residues"}
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -181,6 +206,7 @@ export const MoorhenContextMenu = (props) => {
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
                           refineAfterMod={false}
+                          toolTip={props.shortCuts ? `Delete Item ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).delete_residue)}` : "Delete Item"}
                           onExit={deleteMoleculeIfEmpty}
                           cootCommandInput={{
                               message: 'coot_command',
@@ -196,6 +222,7 @@ export const MoorhenContextMenu = (props) => {
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
                           needsMapData={true}
+                          toolTip={props.shortCuts ? `Add Residue ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).add_terminal_residue)}` : "Add Residue"}
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -209,6 +236,7 @@ export const MoorhenContextMenu = (props) => {
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/spin-view.svg`} alt='Eigen flip'/>}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
+                          toolTip={props.shortCuts ? `Eigen Flip: flip the ligand around its eigenvectors ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).eigen_flip)}` : "Eigen Flip: flip the ligand around its eigenvectors"}
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -222,6 +250,7 @@ export const MoorhenContextMenu = (props) => {
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/edit-chi.svg`} alt='jed-flip'/>}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
+                          toolTip="JED Flip: wag the tail"
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -235,19 +264,7 @@ export const MoorhenContextMenu = (props) => {
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/jed-flip-reverse.svg`} alt='jed-flip-reverse'/>}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
-                          cootCommandInput={{
-                              message: 'coot_command',
-                              returnType: "status",
-                              command: 'jed_flip',
-                              commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`, true],
-                              changesMolecules: [selectedMolecule.molNo]
-                          }}
-                          {...props}
-                      />
-                      <MoorhenContextQuickEditButton 
-                          icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/jed-flip-reverse.svg`} alt='jed-flip-reverse'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
+                          toolTip="JED Flip: wag the dog"
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -262,6 +279,7 @@ export const MoorhenContextMenu = (props) => {
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
                           refineAfterMod={false}
+                          toolTip="Add alternative conformation"
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -275,6 +293,7 @@ export const MoorhenContextMenu = (props) => {
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" alt="Cis/Trans" src={`${props.urlPrefix}/baby-gru/pixmaps/cis-trans.svg`}/>}
                           selectedMolecule={selectedMolecule}
                           chosenAtom={chosenAtom}
+                          toolTip="Cis/Trans isomerisation"
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",

--- a/baby-gru/src/components/MoorhenContextMenu.js
+++ b/baby-gru/src/components/MoorhenContextMenu.js
@@ -1,45 +1,81 @@
 import styled, { css } from "styled-components";
 import { ClickAwayListener, FormGroup, IconButton, List, MenuItem, Tooltip } from '@mui/material';
+import { CheckOutlined, CloseOutlined } from "@mui/icons-material";
 import { MoorhenMergeMoleculesMenuItem, MoorhenGetMonomerMenuItem, MoorhenFitLigandRightHereMenuItem, MoorhenImportFSigFMenuItem } from "./MoorhenMenuItem";
-import { cidToSpec, convertViewtoPx, getTooltipShortcutLabel } from "../utils/MoorhenUtils";
-import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
-import { Button, Overlay } from "react-bootstrap"
+import { cidToSpec, getTooltipShortcutLabel } from "../utils/MoorhenUtils";
+import { useRef, useState, useCallback } from "react";
+import { Popover, Overlay, FormLabel, FormSelect, Button, Stack, Form, Card } from "react-bootstrap";
+import { deleteFormatArgs, rigidBodyFitFormatArgs } from "./MoorhenSimpleEditButton";
+import { useEffect } from "react";
 
 const ContextMenu = styled.div`
   position: absolute;
-  
   border-radius: 5px;
   box-sizing: border-box;
   border-color: #4a4a4a;
   border-width: 1px;
   border-style: solid;
-  ${({ top, left, backgroundColor }) => css`
+  ${({ top, left, backgroundColor, opacity }) => css`
     top: ${top}px;
     left: ${left}px;
     background-color: ${backgroundColor};
+    opacity: ${opacity};
     `}
 `;
 
-const MoorhenContextQuickEditButton = (props) => {
-  const target = useRef(null)
-  const [prompt, setPrompt] = useState(null)
-  const [localParameters, setLocalParameters] = useState({})
-
-  useEffect(() => {
-      setPrompt(props.prompt)
-  }, [props.prompt])
-
-  useEffect(() => {
-      setLocalParameters(props.panelParameters)
+const MoorhenPopoverOptions = (props) => {
+  const selectRef = useRef(null)
+  const extraInputRef = useRef(null)
+  
+  const handleRightClick = useCallback((e) => {
+    if (props.showContextMenu) {
+      props.setShowOverlay(false)
+    }
   }, [])
 
   useEffect(() => {
-      setLocalParameters(props.panelParameters)
-  }, [props.panelParameters])
+    document.addEventListener("rightClick", handleRightClick);
+    return () => {
+        document.removeEventListener("rightClick", handleRightClick);
+    };
 
-  const handleClick = async () => {
-    const cootResult = await props.commandCentre.current.cootCommand(props.cootCommandInput)
+}, [handleRightClick]);
+
+  return <ClickAwayListener onClickAway={() => props.setShowOverlay(false)}>
+          <Stack direction="vertical" gap={2}>
+            <FormGroup>
+              <FormLabel>{props.label}</FormLabel>
+              <FormSelect ref={selectRef} defaultValue='TRIPLE'>
+                  {props.options.map(optionName => {
+                      return <option key={optionName} value={optionName}>{optionName}</option>
+                  })}
+              </FormSelect>
+            </FormGroup>
+            {props.extraInput(extraInputRef)}
+            <Button onClick={() => {
+              if (!props.nonCootCommand) {
+                props.doEdit(props.formatArgs(selectRef.current.value, extraInputRef))
+              } else {
+                props.nonCootCommand(props.selectedMolecule, props.chosenAtom, selectRef.current.value)
+              }
+            }}>
+              OK
+            </Button>
+          </Stack>
+        </ClickAwayListener>
+}
+
+MoorhenPopoverOptions.defaultProps = {extraInput: () => null, nonCootCommand: false}
+
+const MoorhenContextQuickEditButton = (props) => {
+
+  const doEdit = async (cootCommandInput) => {
+    const cootResult = await props.commandCentre.current.cootCommand(cootCommandInput)
    
+    if (props.onCompleted) {
+      props.onCompleted(props.selectedMolecule, props.chosenAtom)
+    }
+
     if (props.refineAfterMod && props.activeMap) {
       try {
           await props.commandCentre.current.cootCommand({
@@ -63,17 +99,29 @@ const MoorhenContextQuickEditButton = (props) => {
     ])
 
     if(props.onExit) {
-      props.onExit(props.selectedMolecule, cootResult)
+      props.onExit(props.selectedMolecule, props.chosenAtom, cootResult)
     }
 
     props.setShowContextMenu(false)
+
+  }
+
+  const handleClick = async () => {
+    if (props.popoverSettings) {
+      props.setOverlayContents(
+        <MoorhenPopoverOptions {...props.popoverSettings} chosenAtom={props.chosenAtom} selectedMolecule={props.selectedMolecule} showContextMenu={props.showContextMenu} doEdit={doEdit} setShowOverlay={props.setShowOverlay}/>
+      )
+      setTimeout(() => props.setShowOverlay(true), 50)
+    } else {
+      await doEdit(props.cootCommandInput)
+    }
   }
 
   return <>
           <Tooltip title={(props.needsMapData && !props.activeMap) || (props.needsAtomData && props.molecules.length === 0) ? '' : props.toolTip}>
               <IconButton 
                 onClick={handleClick}
-                style={{width:'2rem', height: '2rem', margin: 0, paddingRight: 0, paddingTop: 0, paddingBottom: 0, paddingLeft: '0.1rem'}}
+                style={{width:'3rem', height: '3rem', marginTop: '0.5rem', paddingRight: 0, paddingTop: 0, paddingBottom: 0, paddingLeft: '0.1rem'}}
                 disabled={props.needsMapData && !props.activeMap || (props.needsAtomData && props.molecules.length === 0)}
               >
                 {props.icon}
@@ -83,24 +131,18 @@ const MoorhenContextQuickEditButton = (props) => {
 }
 
 MoorhenContextQuickEditButton.defaultProps = {
-  needsMapData: false, needsAtomData: true, refineAfterMod: false, onExit: null
+  needsMapData: false, needsAtomData: true, 
+  refineAfterMod: false, onExit: null, onCompleted: null
 }
 
 export const MoorhenContextMenu = (props) => {
-
-  const handleRemoveHydrogens = async (selectedMolecule) => {
-    await props.commandCentre.current.cootCommand({
-      message: 'coot_command',
-      command: 'delete_hydrogen_atoms',
-      returnType: 'status',
-      commandArgs: [selectedMolecule.molNo]
-    })
-
-    selectedMolecule.setAtomsDirty(true)
-    selectedMolecule.redraw(props.glRef)
-    props.setShowContextMenu(false)
-  }
-
+  const contextMenuRef = useRef(null)
+  const quickActionsFormGroupRef = useRef(null)
+  const [showOverlay, setShowOverlay] = useState(false)
+  const [overlayContents, setOverlayContents] = useState(null)
+  const [overrideMenuContents, setOverrideMenuContents] = useState(false)
+  const [opacity, setOpacity] = useState(1.0)
+  
   const handleCreateBackup = async () => {
     const session = await props.timeCapsuleRef.current.fetchSession()
     const sessionString = JSON.stringify(session)
@@ -110,6 +152,89 @@ export const MoorhenContextMenu = (props) => {
     props.setShowContextMenu(false)
   }
 
+  const doRotateTranslate = async (molecule, chosenAtom, selectedMode) => {
+    let fragmentCid
+    switch (selectedMode) {
+        case 'ATOM':
+            fragmentCid = `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`
+            break;
+        case 'RESIDUE':
+            fragmentCid = `//${chosenAtom.chain_id}/${chosenAtom.res_no}/*${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`
+            break;
+        case 'CHAIN':
+            fragmentCid = `//${chosenAtom.chain_id}`
+            break;
+        case 'MOLECULE':
+            fragmentCid = `/*/*`
+            break;
+        default:
+            console.log('Unrecognised rotate/translate selection...')
+            break;        
+    }
+    
+    if (!fragmentCid) {
+        return
+    }
+    
+    molecule.hideCid(fragmentCid, props.glRef)
+    const newMolecule = await molecule.copyFragmentUsingCid(
+      fragmentCid, props.glRef.current.background_colour, molecule.cootBondsOptions.smoothness, props.glRef, false
+    )
+    await newMolecule.updateAtoms()
+    
+    Object.keys(molecule.displayObjects)
+      .filter(style => { return ['CRs', 'CBs', 'ligands', 'gaussian', 'MolecularSurface', 'VdWSurface', 'DishyBases'].includes(style) })
+      .forEach(async style => {
+          if (molecule.displayObjects[style].length > 0 &&
+              molecule.displayObjects[style][0].visible) {
+              await newMolecule.drawWithStyleFromAtoms(style, props.glRef)
+          }
+    })
+    
+    const acceptTransform = async () => {
+      props.glRef.current.setActiveMolecule(null)
+      const transformedAtoms = newMolecule.transformedCachedAtomsAsMovedAtoms(props.glRef)
+      await molecule.updateWithMovedAtoms(transformedAtoms, props.glRef)
+      props.changeMolecules({ action: 'Remove', item: newMolecule })
+      newMolecule.delete(props.glRef)
+      molecule.unhideAll(props.glRef)
+      setOverrideMenuContents(false)
+      setOpacity(1)
+      const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
+      document.dispatchEvent(mapUpdateEvent)
+    }
+
+    const rejectTransform = async () => {
+      props.glRef.current.setActiveMolecule(null)
+      props.changeMolecules({ action: 'Remove', item: newMolecule })
+      newMolecule.delete(props.glRef)
+      molecule.unhideAll(props.glRef)
+      setOverrideMenuContents(false)
+      setOpacity(1)
+    }
+    
+    props.changeMolecules({ action: "Add", item: newMolecule })
+    props.glRef.current.setActiveMolecule(newMolecule)
+    setShowOverlay(false)
+    setOpacity(0.5)
+    setOverrideMenuContents(
+      <Card onMouseOver={() => setOpacity(1)} onMouseOut={() => setOpacity(0.5)} >
+        <Card.Header>Accept rotate/translate ?</Card.Header>
+        <Card.Body style={{ alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
+          <em>{"Hold <Shift><Alt> to translate"}</em>
+          <br></br>
+          <em>{props.shortCuts ? `Hold ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).residue_camera_wiggle)} to move view` : null}</em>
+          <br></br>
+          <br></br>
+          <Stack direction='horizontal' gap={2}>
+            <Button onClick={acceptTransform}><CheckOutlined /></Button>
+            <Button onClick={rejectTransform}><CloseOutlined /></Button>
+          </Stack>
+        </Card.Body>
+      </Card>
+    )
+}
+
   const deleteMoleculeIfEmpty = (molecule, cootResult) => {
     if (cootResult.data.result.result.second < 1) {
         console.log('Empty molecule detected, deleting it now...')
@@ -117,6 +242,24 @@ export const MoorhenContextMenu = (props) => {
         props.changeMolecules({ action: 'Remove', item: molecule })
     }
   }
+
+  const autoFitRotamer = useCallback(async (molecule, chosenAtom) => {
+    const formattedArgs = [
+        molecule.molNo,
+        chosenAtom.chain_id,
+        chosenAtom.res_no,
+        chosenAtom.ins_code,
+        chosenAtom.alt_conf,
+        props.activeMap.molNo
+    ]
+    await props.commandCentre.current.cootCommand({
+        returnType: "status",
+        command: "auto_fit_rotamer",
+        commandArgs: formattedArgs,
+        changesMolecules: [molecule.molNo]
+    }, true)
+  }, [props.activeMap, props.commandCentre])
+
 
   const top = props.showContextMenu.pageY
   const left = props.showContextMenu.pageX
@@ -130,23 +273,26 @@ export const MoorhenContextMenu = (props) => {
     chosenAtom = cidToSpec(props.showContextMenu.atom.label)
   }
 
-  return <ContextMenu top={top} left={left} backgroundColor={backgroundColor}>
-              <ClickAwayListener onClickAway={() => props.setShowContextMenu(false)}>
+  const collectedProps = {selectedMolecule, chosenAtom, setOverlayContents, setShowOverlay, ...props}
+
+  return <>
+      <ContextMenu ref={contextMenuRef} top={top} left={left} backgroundColor={backgroundColor} opacity={opacity}>
+        {overrideMenuContents ? 
+        overrideMenuContents 
+        :
+              <ClickAwayListener onClickAway={() => !showOverlay && props.setShowContextMenu(false)}>
                   <List>
                     {selectedMolecule && chosenAtom ?
                     <>
                      <MoorhenMergeMoleculesMenuItem glRef={props.glRef} molecules={props.molecules} setPopoverIsShown={() => {}} menuItemText="Merge molecule into..." popoverPlacement='right' fromMolNo={selectedMolecule.molNo}/>
-                     <MenuItem onClick={() => handleRemoveHydrogens(selectedMolecule)}>Remove hydrogens</MenuItem>
                      <MoorhenImportFSigFMenuItem glRef={props.glRef} molecules={props.molecules} setPopoverIsShown={() => {}} selectedMolNo={selectedMolecule.molNo} maps={props.maps} commandCentre={props.commandCentre} />
                      <MenuItem onClick={() => handleCreateBackup()}>Create backup</MenuItem>
                      <hr></hr>
-                     <FormGroup style={{ margin: "0px", padding: "0px", width: '20rem' }} row>
+                     <FormGroup ref={quickActionsFormGroupRef} style={{ margin: "0px", padding: "0px", width: '21rem' }} row>
                       <MoorhenContextQuickEditButton 
                           toolTip={props.shortCuts ? `Auto-fit Rotamer ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).auto_fit_rotamer)}` : "Auto-fit Rotamer"}
                           icon={<img style={{width:'100%', height: '100%'}} src={`${props.urlPrefix}/baby-gru/pixmaps/auto-fit-rotamer.svg`} alt='Auto-Fit rotamer'/>}
                           needsMapData={true}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           cootCommandInput={{
                               message: 'coot_command',
                               returnType: "status",
@@ -154,13 +300,11 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, chosenAtom.chain_id, chosenAtom.res_no, chosenAtom.ins_code],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} src={`${props.urlPrefix}/baby-gru/pixmaps/flip-peptide.svg`} alt='Flip peptide'/>}
                           needsMapData={true}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip={props.shortCuts ? `Flip Peptide ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).flip_peptide)}` : "Flip Peptide"}
                           cootCommandInput={{
                               message: 'coot_command',
@@ -169,12 +313,10 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, ''],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/side-chain-180.svg`} alt='Rotate Side-chain'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip="Rotate side-chain 180 degrees"
                           cootCommandInput={{
                               message: 'coot_command',
@@ -183,44 +325,74 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/refine-1.svg`} alt='Refine Residues'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           needsMapData={true}
                           refineAfterMod={false}
                           toolTip={props.shortCuts ? `Refine Residues ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).triple_refine)}` : "Refine Residues"}
-                          cootCommandInput={{
-                              message: 'coot_command',
-                              returnType: "status",
-                              command: 'refine_residues_using_atom_cid',
-                              commandArgs: [ selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, 'TRIPLE'],
-                              changesMolecules: [selectedMolecule.molNo]
-                          }}
-                          {...props}
+                          popoverSettings={{
+                            label: 'Refinement mode',
+                            options: ['SINGLE', 'TRIPLE', 'QUINTUPLE', 'HEPTUPLE', 'SPHERE', 'BIG_SPHERE', 'CHAIN', 'ALL'],
+                            formatArgs: (selectedOption) => {
+                              return {
+                                message: 'coot_command',
+                                returnType: "status",
+                                command: 'refine_residues_using_atom_cid',
+                                commandArgs: [ selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, selectedOption],
+                                changesMolecules: [selectedMolecule.molNo]
+                              }
+                            }
+                            }}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/delete.svg`} alt="delete-item"/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           refineAfterMod={false}
                           toolTip={props.shortCuts ? `Delete Item ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).delete_residue)}` : "Delete Item"}
                           onExit={deleteMoleculeIfEmpty}
-                          cootCommandInput={{
-                              message: 'coot_command',
-                              returnType: "status",
-                              command: 'delete_using_cid',
-                              commandArgs: [selectedMolecule.molNo, `/1/${chosenAtom.chain_id}/${chosenAtom.res_no}/*${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`, 'LITERAL'],
-                              changesMolecules: [selectedMolecule.molNo]
-                          }}
-                          {...props}
+                          popoverSettings={{
+                            label: 'Delete mode',
+                            options: ['ATOM', 'RESIDUE', 'RESIDUE HYDROGENS', 'RESIDUE SIDE-CHAIN', 'CHAIN', 'CHAIN HYDROGENS', 'MOLECULE HYDROGENS'],
+                            formatArgs: (selectedOption) => {
+                              return {
+                                message: 'coot_command',
+                                returnType: "status",
+                                command: 'delete_using_cid',
+                                commandArgs: deleteFormatArgs(selectedMolecule, chosenAtom, selectedOption),
+                                changesMolecules: [selectedMolecule.molNo]
+                              }
+                            }
+                            }}
+                          {...collectedProps}
+                      />
+                      <MoorhenContextQuickEditButton 
+                          icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/mutate.svg`} alt='Mutate'/>}
+                          refineAfterMod={false}
+                          needsMapData={true}
+                          onCompleted={autoFitRotamer}
+                          toolTip="Mutate residue"
+                          popoverSettings={{
+                            label: 'Mutate to...',
+                            options: [
+                              'ALA', 'CYS', 'ASP', 'GLU', 'PHE', 'GLY', 'HIS', 'ILE', 'LYS', 'LEU',
+                               'MET', 'ASN', 'PRO', 'GLN', 'ARG', 'SER', 'THR', 'VAL', 'TRP', 'TYR'
+                            ],
+                            formatArgs: (selectedOption) => {
+                              return {
+                                message: 'coot_command',
+                                returnType: "status",
+                                command: 'mutate',
+                                commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, selectedOption],
+                                changesMolecules: [selectedMolecule.molNo]
+                              }
+                            }
+                            }}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/add-peptide-1.svg`} alt='Add Residue'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           needsMapData={true}
                           toolTip={props.shortCuts ? `Add Residue ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).add_terminal_residue)}` : "Add Residue"}
                           cootCommandInput={{
@@ -230,12 +402,40 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
+                      />
+                      <MoorhenContextQuickEditButton 
+                          icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/rigid-body.svg`} alt='Rigid body fit'/>}
+                          refineAfterMod={false}
+                          needsMapData={true}
+                          onCompleted={autoFitRotamer}
+                          toolTip="Rigid body fit"
+                          popoverSettings={{
+                            extraInput: (ref) => {
+                              return <Form.Check
+                                            ref={ref}
+                                            style={{paddingTop: '0.1rem'}} 
+                                            type="switch"
+                                            label="Use random jiggle fit"/>
+                            },
+                            label: 'Fitting mode',
+                            options: ['SINGLE', 'TRIPLE', 'QUINTUPLE', 'HEPTUPLE', 'CHAIN', 'ALL'],
+                            formatArgs: (selectedOption, extraInputRef) => {
+                              const randomJiggleMode = extraInputRef.current.checked
+                              const commandArgs = rigidBodyFitFormatArgs(selectedMolecule, chosenAtom, selectedOption, props.activeMap.molNo)
+                              return {
+                                message: 'coot_command',
+                                returnType: "status",
+                                command: randomJiggleMode ? 'fit_to_map_by_random_jiggle_using_cid' : 'rigid_body_fit',
+                                commandArgs: randomJiggleMode ?  [...commandArgs.slice(0, 2), 0, -1] : commandArgs,
+                                changesMolecules: [selectedMolecule.molNo]
+                              }
+                            }
+                            }}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/spin-view.svg`} alt='Eigen flip'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip={props.shortCuts ? `Eigen Flip: flip the ligand around its eigenvectors ${getTooltipShortcutLabel(JSON.parse(props.shortCuts).eigen_flip)}` : "Eigen Flip: flip the ligand around its eigenvectors"}
                           cootCommandInput={{
                               message: 'coot_command',
@@ -244,12 +444,10 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/edit-chi.svg`} alt='jed-flip'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip="JED Flip: wag the tail"
                           cootCommandInput={{
                               message: 'coot_command',
@@ -258,12 +456,10 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`, false],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/jed-flip-reverse.svg`} alt='jed-flip-reverse'/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip="JED Flip: wag the dog"
                           cootCommandInput={{
                               message: 'coot_command',
@@ -272,12 +468,20 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`, true],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
+                      />
+                      <MoorhenContextQuickEditButton 
+                          icon={<img style={{width:'100%', height: '100%'}} alt="rotate/translate" className="baby-gru-button-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/rtz.svg`}/>}
+                          toolTip="Rotate/Translate zone"
+                          popoverSettings={{
+                            label: 'Rotate/translate mode...',
+                            options: ['ATOM', 'RESIDUE', 'CHAIN', 'MOLECULE'],
+                            nonCootCommand: doRotateTranslate,
+                            }}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" alt="Add side chain" src={`${props.urlPrefix}/baby-gru/pixmaps/add-alt-conf.svg`}/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           refineAfterMod={false}
                           toolTip="Add alternative conformation"
                           cootCommandInput={{
@@ -287,12 +491,10 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs:  [selectedMolecule.molNo, `/1/${chosenAtom.chain_id}/${chosenAtom.res_no}/*${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                       <MoorhenContextQuickEditButton 
                           icon={<img style={{width:'100%', height: '100%'}} className="baby-gru-button-icon" alt="Cis/Trans" src={`${props.urlPrefix}/baby-gru/pixmaps/cis-trans.svg`}/>}
-                          selectedMolecule={selectedMolecule}
-                          chosenAtom={chosenAtom}
                           toolTip="Cis/Trans isomerisation"
                           cootCommandInput={{
                               message: 'coot_command',
@@ -301,7 +503,7 @@ export const MoorhenContextMenu = (props) => {
                               commandArgs:  [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`],
                               changesMolecules: [selectedMolecule.molNo]
                           }}
-                          {...props}
+                          {...collectedProps}
                       />
                      </FormGroup>
                     </>
@@ -314,7 +516,17 @@ export const MoorhenContextMenu = (props) => {
                      }
                     
                   </List>
-              </ClickAwayListener>
+        </ClickAwayListener>
+        }
           </ContextMenu>
+          <Overlay placement="right" show={showOverlay} target={quickActionsFormGroupRef.current}>
+              <Popover>
+              <Popover.Body>
+                {overlayContents}
+              </Popover.Body>
+            </Popover>          
+          </Overlay>
+          </>
+        
 
 }

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -356,6 +356,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
                     setShowContextMenu={setShowContextMenu}
                     activeMap={props.activeMap}
                     refineAfterMod={props.preferences.refineAfterMod}
+                    shortCuts={props.preferences.shortCuts}
                 />}
             </>
 });


### PR DESCRIPTION
After this update, all the edit buttons found in the bottom button bar are also accessible in the context menu when a residue is selected.