### PR TITLE
Backlups store information about connected molecules and maps

### DIFF
--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1207,18 +1207,15 @@ export const MoorhenImportFSigFMenuItem = (props) => {
     const moleculeSelectRef = useRef(null)
 
     const connectMap = async () => {
-        const connectMapsArgs = [
+        const [molecule, reflectionMap, twoFoFcMap, foFcMap] = [
             props.selectedMolNo !== null ? props.selectedMolNo : parseInt(moleculeSelectRef.current.value),
             parseInt(mapSelectRef.current.value),
             parseInt(twoFoFcSelectRef.current.value),
-            parseInt(foFcSelectRef.current.value),
+            parseInt(foFcSelectRef.current.value)
         ]
-        const sFcalcArgs = [
-            props.selectedMolNo !== null ? props.selectedMolNo : parseInt(moleculeSelectRef.current.value),
-            parseInt(twoFoFcSelectRef.current.value),
-            parseInt(foFcSelectRef.current.value),
-            parseInt(mapSelectRef.current.value)
-        ]
+
+        const connectMapsArgs = [molecule, reflectionMap, twoFoFcMap, foFcMap]
+        const sFcalcArgs = [molecule, twoFoFcMap, foFcMap, reflectionMap]
 
         if (connectMapsArgs.every(arg => !isNaN(arg))) {
             await props.commandCentre.current.cootCommand({
@@ -1235,8 +1232,9 @@ export const MoorhenImportFSigFMenuItem = (props) => {
 
             const connectedMapsEvent = new CustomEvent("connectMaps", {
                 "detail": {
-                    molecule: connectMapsArgs[0],
-                    maps: [...new Set(connectMapsArgs.slice(1))]
+                    molecule: molecule,
+                    maps: [reflectionMap, twoFoFcMap, foFcMap],
+                    uniqueMaps: [...new Set([reflectionMap, twoFoFcMap, foFcMap].slice(1))]
                 }
             })
             document.dispatchEvent(connectedMapsEvent)

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -124,6 +124,10 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
     const handleDisconnectMaps = () => {
         scores.current = {}
+        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === connectedMolNo.molecule)
+        if (selectedMolecule) {
+            selectedMolecule.connectedToMaps = null
+        }
         setConnectedMolNo(null)
         setScoreToastContents(null)
     }
@@ -162,8 +166,16 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             rFree: currentScores.data.result.result.free_r_factor
         }
 
+        if (connectedMolNo && evt.detail.molecule !== connectedMolNo.molecule) {
+            const previousConnectedMolecule = props.molecules.find(molecule => molecule.molNo === connectedMolNo.molecule)
+            previousConnectedMolecule.connectedToMaps = null    
+        }
+
         setConnectedMolNo(evt.detail)
-    }, [props.commandCentre, props.preferences.defaultUpdatingScores])
+        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === evt.detail.molecule)
+        selectedMolecule.connectedToMaps = evt.detail.maps
+        
+    }, [props.commandCentre, props.preferences.defaultUpdatingScores, props.molecules, connectedMolNo])
 
     useEffect(() => {
         if (scores.current !== null && props.preferences.defaultUpdatingScores !== null && props.preferences.showScoresToast && connectedMolNo) {
@@ -307,7 +319,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     useEffect(() => {
         if (connectedMolNo && props.maps.lenght === 0){
             handleDisconnectMaps()
-        } else if (connectedMolNo && !connectedMolNo.maps.every(mapMolNo => props.maps.includes(mapMolNo))){
+        } else if (connectedMolNo && !connectedMolNo.uniqueMaps.every(mapMolNo => props.maps.includes(mapMolNo))){
             handleDisconnectMaps()
         }
         props.maps.forEach(map => {
@@ -357,6 +369,8 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
                     activeMap={props.activeMap}
                     refineAfterMod={props.preferences.refineAfterMod}
                     shortCuts={props.preferences.shortCuts}
+                    windowWidth={props.windowWidth}
+                    windowHeight={props.windowHeight}
                 />}
             </>
 });

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -26,6 +26,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
     this.sequences = []
     this.colourRules = null
     this.ligands = null
+    this.connectedToMaps = null
     this.excludedSegments = []
     this.gaussianSurfaceSettings = {
         sigma: 4.4,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.js
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.js
@@ -22,7 +22,7 @@ export function MoorhenTimeCapsule(moleculesRef, mapsRef, activeMapRef, glRef, p
     this.modificationCount = 0
     this.modificationCountBackupThreshold = 5
     this.maxBackupCount = 10
-    this.version = '0.0.6'
+    this.version = '0.0.7'
     this.storageInstance = createInstance('Moorhen-TimeCapsule')
     this.checkVersion()
 }
@@ -124,15 +124,18 @@ MoorhenTimeCapsule.prototype.fetchSession = async function (includeAdditionalMap
     const moleculeData = this.moleculesRef.current.map((molecule, index) => {
         return {
             name: molecule.name,
+            molNo: molecule.molNo,
             pdbData: moleculeDataPromises[index],
             displayObjectsKeys: Object.keys(molecule.displayObjects).filter(key => molecule.displayObjects[key].length > 0),
-            cootBondsOptions: molecule.cootBondsOptions
+            cootBondsOptions: molecule.cootBondsOptions,
+            connectedToMaps: molecule.connectedToMaps
         }
     })
 
     const mapData = this.mapsRef.current.map((map, index) => {
         return {
             name: map.name,
+            molNo: map.molNo,
             uniqueId: map.uniqueId,
             mapData: mapDataPromises[index],
             reflectionData: reflectionDataPromises[index],


### PR DESCRIPTION
After this update, when loading a backup moorhen will automatically connect molecules and maps that were connected in the loaded session.