### PR TITLE
Only pack minimal monomer library and pixmaps

### DIFF
--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -18,6 +18,17 @@ export default class MoorhenWrapper {
     reportWebVitals()
   }
 
+  get monomerLibrary() {
+    if (this.monomerLibrary !== null) {
+      return this.monomerLibrary
+    } 
+    return `${this.urlPrefix}/baby-gru/monomers/`
+  }
+
+  addMonomerLibrary(uri) {
+    this.monomerLibrary = uri
+  }
+
   async exportBackups() {
     const keys = await this.controls.timeCapsuleRef.current.storageInstance.keys()
     const responses = await Promise.all(
@@ -70,10 +81,6 @@ export default class MoorhenWrapper {
     this.exportCallback = callbackFunction
   }
 
-  addMonomerLibrary(monomerLibrary){
-    this.monomerLibrary = monomerLibrary
-  }
-  
   forwardControls(controls) {
     console.log('Fetched controls', {controls})
     this.controls = controls
@@ -106,7 +113,7 @@ export default class MoorhenWrapper {
   }
 
   async loadPdbData(inputFile, molName) {
-    const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.urlPrefix)
+    const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.monomerLibrary)
     return new Promise(async (resolve, reject) => {
         try {
             await newMolecule.loadToCootFromURL(inputFile, molName)
@@ -159,10 +166,11 @@ export default class MoorhenWrapper {
         <div className="App">
           <PreferencesContextProvider>
             <MoorhenContainer 
+              urlPrefix={this.urlPrefix}
               forwardControls={this.forwardControls.bind(this)}
               disableFileUploads={true}
               exportCallback={this.exportCallback.bind(this)}
-              monomerLibrary={this.monomerLibrary}
+              monomerLibraryPath={this.monomerLibrary}
               />
           </PreferencesContextProvider>
         </div>

--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -13,16 +13,9 @@ export default class MoorhenWrapper {
   constructor(urlPrefix) {
     this.urlPrefix = urlPrefix
     this.controls = null
-    this.monomerLibrary = null
+    this.monomerLibrary = `${this.urlPrefix}/baby-gru/monomers/`
     this.exportCallback = () => {}
     reportWebVitals()
-  }
-
-  get monomerLibrary() {
-    if (this.monomerLibrary !== null) {
-      return this.monomerLibrary
-    } 
-    return `${this.urlPrefix}/baby-gru/monomers/`
   }
 
   addMonomerLibrary(uri) {

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -281,7 +281,7 @@ export const MoorhenContainer = (props) => {
         setToastContent, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, showToast, setShowToast,
         windowWidth, windowHeight, innerWindowMarginWidth, showColourRulesToast, timeCapsuleRef, setShowColourRulesToast, 
         isDark, exportCallback: props.exportCallback, disableFileUploads: props.disableFileUploads, urlPrefix: props.urlPrefix, 
-        extraMenus:props.extraMenus, ...preferences
+        extraMenus:props.extraMenus, monomerLibraryPath: props.monomerLibraryPath, ...preferences
     }
 
     return <> <div>
@@ -348,6 +348,7 @@ export const MoorhenContainer = (props) => {
 
 MoorhenContainer.defaultProps = {
     urlPrefix: '.',
+    monomerLibraryPath: './baby-gru/monomers',
     exportCallback: null,
     disableFileUploads: false,
     extraMenus:[]

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -40,7 +40,7 @@ export const MoorhenFileMenu = (props) => {
     }
 
     const readPdbFile = (file) => {
-        const newMolecule = new MoorhenMolecule(commandCentre, props.urlPrefix)
+        const newMolecule = new MoorhenMolecule(commandCentre, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(props.backgroundColor)
         newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         return newMolecule.loadToCootFromFile(file)
@@ -117,7 +117,7 @@ export const MoorhenFileMenu = (props) => {
     }
 
     const fetchMoleculeFromURL = (url, molName) => {
-        const newMolecule = new MoorhenMolecule(commandCentre, props.urlPrefix)
+        const newMolecule = new MoorhenMolecule(commandCentre, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(props.backgroundColor)
         newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         return new Promise(async (resolve, reject) => {
@@ -178,7 +178,7 @@ export const MoorhenFileMenu = (props) => {
 
         // Load molecules stored in session from pdb string
         const newMoleculePromises = sessionData.moleculeData.map(storedMoleculeData => {
-            const newMolecule = new MoorhenMolecule(commandCentre, props.urlPrefix)
+            const newMolecule = new MoorhenMolecule(commandCentre, props.monomerLibraryPath)
             return newMolecule.loadToCootFromString(storedMoleculeData.pdbData, storedMoleculeData.name)
         })
         

--- a/baby-gru/src/components/MoorhenHistoryMenu.js
+++ b/baby-gru/src/components/MoorhenHistoryMenu.js
@@ -75,7 +75,7 @@ export const MoorhenHistoryMenu = (props) => {
                     // If this was a command to read a molecule, then teh corresponding
                     //MoorhenMolecule has to be created
                     if (nextCommand.command === 'shim_read_pdb') {
-                        const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+                        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
                         newMolecule.molNo = reply.data.result.result
                         newMolecule.name = nextCommand.commandArgs[1]
                         newMolecule.centreOn(props.glRef, null, false)

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -111,7 +111,7 @@ export const MoorhenLoadTutorialDataMenuItem = (props) => {
 
     const onCompleted = (onCompletedArg) => {
         const tutorialNumber = tutorialNumberSelectorRef.current.value
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(props.backgroundColor)
         newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
         const newMap = new MoorhenMap(props.commandCentre)
@@ -164,7 +164,7 @@ export const MoorhenGetMonomerMenuItem = (props) => {
     const onCompleted = () => {
         const fromMolNo = parseInt(selectRef.current.value)
         const newTlc = tlcRef.current.value
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
 
         const getMonomer = () => {
             return props.commandCentre.current.cootCommand({
@@ -186,7 +186,7 @@ export const MoorhenGetMonomerMenuItem = (props) => {
             })
             .then(result => {
                 if (result.data.result.status === "Completed" && result.data.result.result !== -1) {
-                    const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+                    const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
                     newMolecule.molNo = result.data.result.result
                     newMolecule.name = newTlc
                     newMolecule.setBackgroundColour(props.backgroundColor)
@@ -239,7 +239,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
             .then(result => {
                 if (result.data.result.status === "Completed") {
                     result.data.result.result.forEach(iMol => {
-                        const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+                        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
                         newMolecule.molNo = iMol
                         newMolecule.name = `lig_${iMol}`
                         newMolecule.setBackgroundColour(props.backgroundColor)
@@ -933,7 +933,7 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
                     }, true)
                         .then(result => {
                             if (result.data.result.status === "Completed") {
-                                newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+                                newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
                                 newMolecule.molNo = result.data.result.result
                                 newMolecule.name = instanceName
                                 newMolecule.setBackgroundColour(props.backgroundColor)
@@ -978,7 +978,7 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
     }
 
     const readMonomerFile = async (newTlc) => {
-        return fetch(`${props.urlPrefix}/baby-gru/monomers/${newTlc.toLowerCase()[0]}/${newTlc.toUpperCase()}.cif`)
+        return fetch(`${props.monomerLibraryPath}/${newTlc.toLowerCase()[0]}/${newTlc.toUpperCase()}.cif`)
             .then(response => response.text())
             .then(fileContent => {
                 return handleFileContent(fileContent)
@@ -1666,7 +1666,7 @@ export const MoorhenCopyFragmentUsingCidMenuItem = (props) => {
             commandArgs: commandArgs,
             changesMolecules: [parseInt(fromRef.current.value)]
         }, true).then(async response => {
-            const newMolecule = new MoorhenMolecule(props.commandCentre, props.urlPrefix)
+            const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
             newMolecule.name = `${fromMolecules[0].name} fragment`
             newMolecule.molNo = response.data.result.result
             newMolecule.setBackgroundColour(props.backgroundColor)

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -13,7 +13,7 @@ import * as vec3 from 'gl-matrix/vec3';
 import * as mat3 from 'gl-matrix/mat3';
 import * as quat4 from 'gl-matrix/quat';
 
-export function MoorhenMolecule(commandCentre, urlPrefix) {
+export function MoorhenMolecule(commandCentre, monomerLibraryPath) {
     this.type = 'molecule'
     this.commandCentre = commandCentre
     this.enerLib = new EnerLib()
@@ -55,7 +55,7 @@ export function MoorhenMolecule(commandCentre, urlPrefix) {
         selection: [],
         transformation: { origin: [0, 0, 0], quat: null, centre: [0, 0, 0] }
     }
-    this.urlPrefix = (typeof urlPrefix === 'undefined' ? "." : urlPrefix)
+    this.monomerLibraryPath = (typeof monomerLibraryPath === 'undefined' ? "./baby-gru/monomers" : monomerLibraryPath)
 };
 
 MoorhenMolecule.prototype.setBackgroundColour = function (backgroundColour) {
@@ -154,7 +154,7 @@ MoorhenMolecule.prototype.delete = async function (glRef) {
 MoorhenMolecule.prototype.copyMolecule = async function (glRef) {
 
     let moleculeAtoms = await this.getAtoms()
-    let newMolecule = new MoorhenMolecule(this.commandCentre, this.urlPrefix)
+    let newMolecule = new MoorhenMolecule(this.commandCentre, this.monomerLibraryPath)
     newMolecule.name = `${this.name}-placeholder`
     newMolecule.cootBondsOptions = this.cootBondsOptions
 
@@ -177,7 +177,7 @@ MoorhenMolecule.prototype.copyFragment = async function (chainId, res_no_start, 
     const $this = this
     const inputData = { message: "copy_fragment", molNo: $this.molNo, chainId: chainId, res_no_start: res_no_start, res_no_end: res_no_end }
     const response = await $this.commandCentre.current.postMessage(inputData)
-    const newMolecule = new MoorhenMolecule($this.commandCentre, $this.urlPrefix)
+    const newMolecule = new MoorhenMolecule($this.commandCentre, $this.monomerLibraryPath)
     newMolecule.name = `${$this.name} fragment`
     newMolecule.molNo = response.data.result
     newMolecule.cootBondsOptions = $this.cootBondsOptions
@@ -198,7 +198,7 @@ MoorhenMolecule.prototype.copyFragmentUsingCid = async function (cid, background
         commandArgs: [$this.molNo, cid],
         changesMolecules: [$this.molNo]
     }, true).then(async response => {
-        const newMolecule = new MoorhenMolecule($this.commandCentre, $this.urlPrefix)
+        const newMolecule = new MoorhenMolecule($this.commandCentre, $this.monomerLibraryPath)
         newMolecule.name = `${$this.name} fragment`
         newMolecule.molNo = response.data.result.result
         newMolecule.setBackgroundColour(backgroundColor)
@@ -263,7 +263,7 @@ MoorhenMolecule.prototype.loadToCootFromString = async function (coordData, name
 
 MoorhenMolecule.prototype.loadMissingMonomer = async function (newTlc, attachToMolecule) {
     const $this = this
-    return fetch(`${$this.urlPrefix}/baby-gru/monomers/${newTlc.toLowerCase()[0]}/${newTlc.toUpperCase()}.cif`)
+    return fetch(`${$this.monomerLibraryPath}/${newTlc.toLowerCase()[0]}/${newTlc.toUpperCase()}.cif`)
         .then(response => { return response.text() })
         .then(fileContent => {
             if (!fileContent.includes('data_')) {
@@ -1351,7 +1351,7 @@ MoorhenMolecule.prototype.addLigandOfType = async function (resType, at, glRef) 
     }, true)
         .then(async result => {
             if (result.data.result.status === "Completed") {
-                newMolecule = new MoorhenMolecule($this.commandCentre, $this.urlPrefix)
+                newMolecule = new MoorhenMolecule($this.commandCentre, $this.monomerLibraryPath)
                 newMolecule.setAtomsDirty(true)
                 newMolecule.molNo = result.data.result.result
                 newMolecule.name = resType.toUpperCase()

--- a/baby-gru/webpack.config.js
+++ b/baby-gru/webpack.config.js
@@ -10,7 +10,28 @@ const paths = {
   dist: path.resolve(__dirname, 'dist'),
   public: path.resolve(__dirname, 'public'),
   publicBabyGru: path.resolve(__dirname, 'public', 'baby-gru'),
-  pixmaps: path.resolve(__dirname, 'public', 'baby-gru', 'pixmaps'),
+  pixmapsPath: path.resolve(__dirname, 'public', 'baby-gru', 'pixmaps'),
+  monomerLibraryPath: path.resolve(__dirname, 'public', 'baby-gru', 'monomers'),
+  minimalMonomerLib: [
+    'ALA', 'ASP', 'ASN', 'CYS', 'GLN', 'GLY', 'GLU', 'PHE', 'HIS', 'ILE', 'LYS', 
+    'LEU', 'MET', 'MSE', 'PRO', 'ARG', 'SER', 'THR', 'VAL', 'TRP', 'TYR', 'PO4',
+    'SO4', 'GOL', 'CIT', 'EDO', 'A', 'C', 'G', 'U', 'DA', 'DC', 'DG', 'DT', 'HOH',
+    'NA'
+  ],
+  requiredPixmaps: [
+    'diff-map.png', 'MoorhenLogo.png', 'rama2_all.png', 'rama2_gly.png',
+    'rama2_pre_pro.png', 'rama2_pro.png', 'rama2_ileval.png', 'rama2_non_gly_pro.png',
+    'rama2_non_gly_pro_pre_pro_ileval.png', 'rama-plot-gly-normal.png', 'mutate.svg', 
+    'rama-plot-pro-normal.png', 'rama-plot-pro-outlier.png', 'rama-plot-other-normal.png',
+    'rama-plot-other-outlier.png', 'auto-fit-rotamer.svg', 'flip-peptide.svg', 
+    'side-chain-180.svg', 'refine-1.svg', 'delete.svg', 'rama-plot-gly-outlier.png',
+    'add-peptide-1.svg', 'rigid-body.svg', 'spin-view.svg', 'edit-chi.svg',
+    'jed-flip-reverse.svg', 'rtz.svg', 'add-alt-conf.svg', 'cis-trans.svg',
+    'auto-fit-rotamer.svg', 'flip-peptide.svg', 'cis-trans.svg', 'side-chain-180.svg',
+    'refine-1.svg', 'add-alt-conf.svg', 'delete.svg', 'mutate.svg', 'temperature.svg',
+    'add-peptide-1.svg', 'spin-view.svg', 'edit-chi.svg', 'jed-flip-reverse.svg',
+    'rigid-body.svg', 'atom-at-pointer.svg', 'diff-map.png', 'map.svg', 'rtz.svg'
+  ]
 }
 
 module.exports = {
@@ -34,7 +55,25 @@ module.exports = {
           from: paths.publicBabyGru,
           to: paths.dist + '/baby-gru/',
           toType: 'dir',
-        }
+          globOptions: {
+            ignore: ['**/monomers/**', '**/pixmaps/**']
+          }
+        },
+        ...paths.minimalMonomerLib.map(monomer => {
+          return {
+            from: path.resolve(paths.monomerLibraryPath, monomer.charAt(0).toLowerCase(), `${monomer}.cif`),
+            to: path.resolve(paths.dist, 'baby-gru', 'monomers', monomer.charAt(0).toLowerCase()),
+            toType: 'dir',  
+          }
+        }),
+        ...paths.requiredPixmaps.map(pixmap => {
+          return {
+            from: path.resolve(paths.pixmapsPath, pixmap),
+            to: path.resolve(paths.dist, 'baby-gru', 'pixmaps'),
+            toType: 'dir',  
+          }
+        })
+
       ],
     }),
   ],


### PR DESCRIPTION
As requested for integration into cloud, after this update only a minimal monomer library and pixmaps are bundled with webpack when building the app and using `build-cloud`. Additionally, `MoorhenMolecule` will look for monomers in a folder passed via `props` to `MoorhenContainer`.