### PR TITLE
separate label atoms and measure atom distances

### DIFF
--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -245,7 +245,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
     }
 
     else if (action === 'clear_labels') {
-        glRef.current.clickedAtoms = []
+        glRef.current.labelledAtoms = []
+        glRef.current.measuredAtoms = []
         glRef.current.drawScene()
         setToastContent(
             <h3>
@@ -321,7 +322,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.myQuat = quat4.create()
         quat4.set(glRef.current.myQuat, 0, 0, 0, -1)
         glRef.current.setZoom(1.0)
-        glRef.current.clickedAtoms = []
+        glRef.current.labelledAtoms = []
+        glRef.current.measuredAtoms = []
         glRef.current.drawScene()
     }
 

--- a/baby-gru/src/utils/MoorhenPreferences.js
+++ b/baby-gru/src/utils/MoorhenPreferences.js
@@ -23,7 +23,7 @@ const updateStoredPreferences = async (key, value) => {
 
 const getDefaultValues = () => {
     return {
-        version: '0.0.17',
+        version: '0.0.18',
         defaultBackgroundColor: [1, 1, 1, 1], 
         atomLabelDepthMode: true, 
         defaultExpandDisplayCards: true,
@@ -131,9 +131,14 @@ const getDefaultValues = () => {
                 keyPress: "z",
                 label: "Wiggle camera while rotating a residue"
             },
-            "label_atom": {
+            "measure_distances": {
                 modifiers: [],
                 keyPress: "m",
+                label: "Measure distances between atoms on click"
+            },
+            "label_atom": {
+                modifiers: [],
+                keyPress: "l",
                 label: "Label an atom on click"
             },
             "center_atom": {


### PR DESCRIPTION
After this update, the keyboard accelerators have changed to allow for a separate "label" atom and "measure" mode. To label an atom hold L & click (L = label). To measure distances, hold M & click (M = measure). I have made the list of labelled atoms and "measured" atom pairs independent from each other so it is possible to label a few atoms and then measure distances between another set of atoms. Hence, `clickedAtoms` has been renamed as `labelledAtoms` and a new list `measuredAtoms` was added to `mgWebGL`.