### PR TITLE
Fix updating scores

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.js
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.js
@@ -3205,8 +3205,6 @@ class MGWebGL extends Component {
             requestAnimationFrame(this.setOriginOrientationAndZoomFrame.bind(this,oo,d,qOld,qNew,oldZoom,zoomDelta,iframe+1))
             return
         }
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: this.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);
         const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} })
         document.dispatchEvent(originUpdateEvent);
     }
@@ -3260,16 +3258,12 @@ class MGWebGL extends Component {
             requestAnimationFrame(this.drawOriginFrame.bind(this,oo,d,iframe+1))
             return
         }
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: this.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);
         const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} })
         document.dispatchEvent(originUpdateEvent);
     }
 
     setOrigin(o, doDrawScene) {
         this.origin = o;
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: this.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);
         const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} })
         document.dispatchEvent(originUpdateEvent);
         //default is to drawScene, unless doDrawScene provided and value is false

--- a/baby-gru/src/components/MoorhenContextMenu.js
+++ b/baby-gru/src/components/MoorhenContextMenu.js
@@ -90,8 +90,8 @@ const MoorhenContextQuickEditButton = (props) => {
       }
     }
 
-    const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.selectedMolecule.molNo } })
-    document.dispatchEvent(mapUpdateEvent)
+    const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.selectedMolecule.molNo } })
+    document.dispatchEvent(scoresUpdateEvent)
     props.selectedMolecule.setAtomsDirty(true)
     await Promise.all([
       props.selectedMolecule.redraw(props.glRef),
@@ -207,8 +207,8 @@ export const MoorhenContextMenu = (props) => {
       molecule.unhideAll(props.glRef)
       setOverrideMenuContents(false)
       setOpacity(1)
-      const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
-      document.dispatchEvent(mapUpdateEvent)
+      const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
+      document.dispatchEvent(scoresUpdateEvent)
     }
 
     const rejectTransform = async () => {

--- a/baby-gru/src/components/MoorhenFillMissingAtoms.js
+++ b/baby-gru/src/components/MoorhenFillMissingAtoms.js
@@ -32,8 +32,8 @@ export const MoorhenFillMissingAtoms = (props) => {
             }
             selectedMolecule.setAtomsDirty(true)
             selectedMolecule.redraw(props.glRef)
-            const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
-            document.dispatchEvent(mapUpdateEvent);    
+            const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
+            document.dispatchEvent(scoresUpdateEvent);    
         }
         if (args.every(arg => arg !== null)) {
             fillPartialResidue(...args)

--- a/baby-gru/src/components/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/components/MoorhenKeyboardAccelerators.js
@@ -9,8 +9,8 @@ const apresEdit = (molecule, glRef, timeCapsuleRef, setHoveredAtom) => {
     molecule.setAtomsDirty(true)
     molecule.redraw(glRef)
     setHoveredAtom({ molecule: null, cid: null })
-    const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: glRef.current.origin,  modifiedMolecule: molecule.molNo} })
-    document.dispatchEvent(mapUpdateEvent)
+    const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin,  modifiedMolecule: molecule.molNo} })
+    document.dispatchEvent(scoresUpdateEvent)
     timeCapsuleRef.current.addModification()
 }
 
@@ -267,8 +267,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);    
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(scoresUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -282,8 +282,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);    
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(scoresUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -297,8 +297,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);    
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(scoresUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }
@@ -312,8 +312,8 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
         glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
         glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(mapUpdateEvent);    
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
+        document.dispatchEvent(scoresUpdateEvent);    
         glRef.current.drawSceneDirty();
         glRef.current.reContourMaps();
     }

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -136,7 +136,7 @@ export const MoorhenMapCard = (props) => {
         }
     }
 
-    const handleUpdateMapCallback = useCallback(e => {
+    const handleOriginUpdate = useCallback(e => {
         nextOrigin.current = [...e.detail.origin.map(coord => -coord)]
         props.map.contourLevel = mapContourLevel
         props.map.mapRadius = mapRadius
@@ -182,17 +182,17 @@ export const MoorhenMapCard = (props) => {
     }, [currentName]);
 
     useEffect(() => {
-        document.addEventListener("mapUpdate", handleUpdateMapCallback);
+        document.addEventListener("originUpdate", handleOriginUpdate);
         document.addEventListener("wheelContourLevelChanged", handleWheelContourLevelCallback);
         document.addEventListener("newMapContour", handleNewMapContour);
         document.addEventListener("mapRadiusChanged", handleRadiusChangeCallback);
         return () => {
-            document.removeEventListener("mapUpdate", handleUpdateMapCallback);
+            document.removeEventListener("originUpdate", handleOriginUpdate);
             document.removeEventListener("wheelContourLevelChanged", handleWheelContourLevelCallback);
             document.removeEventListener("newMapContour", handleNewMapContour);
             document.removeEventListener("mapRadiusChanged", handleRadiusChangeCallback);
         };
-    }, [handleUpdateMapCallback, props.activeMap?.molNo]);
+    }, [handleOriginUpdate, props.activeMap?.molNo]);
 
     useEffect(() => {
         props.map.setAlpha(mapOpacity,props.glRef)

--- a/baby-gru/src/components/MoorhenMapCard.js
+++ b/baby-gru/src/components/MoorhenMapCard.js
@@ -215,7 +215,7 @@ export const MoorhenMapCard = (props) => {
     return <Card className="px-0"  style={{marginBottom:'0.5rem', padding:'0'}} key={props.map.molNo}>
         <Card.Header style={{padding: '0.1rem'}}>
             <Stack gap={2} direction='horizontal'>
-                <Col className='align-items-center' style={{display:'flex', justifyContent:'left'}}>
+                <Col className='align-items-center' style={{display:'flex', justifyContent:'left', color: props.isDark ? 'white' : 'black'}}>
                         {getNameLabel(props.map)}
                         <img 
                             className="baby-gru-map-icon"
@@ -230,7 +230,7 @@ export const MoorhenMapCard = (props) => {
             </Stack>
         </Card.Header>
         <Card.Body style={{display: isCollapsed ? 'none' : ''}}>
-            <Row className="align-items-center" style={{ height: '100%', justifyContent:'between', display:'flex'}}>
+            <Row className="align-items-center" style={{ height: '100%', justifyContent:'between', display:'flex', color: props.isDark ? 'white' : 'black'}}>
                 <Col className="border-left" style={{justifyContent:'left', display:'flex'}}> 
                 <Row>
                         <Form.Check checked={props.map === props.activeMap}

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -342,8 +342,8 @@ export const MoorhenRotateTranslateMoleculeMenuItem = (props) => {
         props.changeMolecules({ action: 'Remove', item: ghostMolecule.current })
         ghostMolecule.current.delete(props.glRef)
         document.body.click()
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: props.molecule.molNo} })
-        document.dispatchEvent(mapUpdateEvent)
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: props.molecule.molNo} })
+        document.dispatchEvent(scoresUpdateEvent)
     }
 
     const rejectTransform = () => {
@@ -958,8 +958,8 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
                             const otherMolecules = [newMolecule]
                             return toMolecule.mergeMolecules(otherMolecules, props.glRef, true)
                                 .then(_ => {
-                                    const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: toMolecule.molNo} })
-                                    document.dispatchEvent(mapUpdateEvent)
+                                    const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: toMolecule.molNo} })
+                                    document.dispatchEvent(scoresUpdateEvent)
                                     return toMolecule.redraw(props.glRef)
                                 })
                         } else {
@@ -1518,8 +1518,8 @@ export const MoorhenMergeMoleculesMenuItem = (props) => {
         }
         await toMolecule.mergeMolecules(otherMolecules, props.glRef, true)
         props.setPopoverIsShown(false)
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: toMolecule.molNo} })
-        document.dispatchEvent(mapUpdateEvent)
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: toMolecule.molNo} })
+        document.dispatchEvent(scoresUpdateEvent)
     }, [toRef.current, fromRef.current, props.molecules, props.fromMolNo, props.glRef])
 
     return <MoorhenMenuItem
@@ -1791,8 +1791,8 @@ export const MoorhenAddWatersMenuItem = (props) => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === molNo)
         selectedMolecule.setAtomsDirty(true)
         await selectedMolecule.redraw(props.glRef)
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: molNo} })
-        document.dispatchEvent(mapUpdateEvent)       
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: molNo} })
+        document.dispatchEvent(scoresUpdateEvent)       
         
     }, [props.molecules, props.activeMap, props.glRef, props.commandCentre])
 

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -264,15 +264,15 @@ export const MoorhenMoleculeCard = (props) => {
     const handleUndo = async () => {
         await props.molecule.undo(props.glRef)
         props.setCurrentDropdownMolNo(-1)
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } })
-        document.dispatchEvent(mapUpdateEvent)
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } })
+        document.dispatchEvent(scoresUpdateEvent)
     }
 
     const handleRedo = async () => {
         await props.molecule.redo(props.glRef)
         props.setCurrentDropdownMolNo(-1)
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } })
-        document.dispatchEvent(mapUpdateEvent)
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } })
+        document.dispatchEvent(scoresUpdateEvent)
     }
 
     const handleCentering = () => {

--- a/baby-gru/src/components/MoorhenMoleculeCard.js
+++ b/baby-gru/src/components/MoorhenMoleculeCard.js
@@ -342,7 +342,7 @@ export const MoorhenMoleculeCard = (props) => {
     return <Card className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.molecule.molNo}>
         <Card.Header style={{ padding: '0.1rem' }}>
             <Stack gap={2} direction='horizontal'>
-                <Col className='align-items-center' style={{ display: 'flex', justifyContent: 'left' }}>
+                <Col className='align-items-center' style={{ display: 'flex', justifyContent: 'left', color: props.isDark ? 'white' : 'black'}}>
                     {getNameLabel(props.molecule)}
                 </Col>
                 <Col style={{ display: 'flex', justifyContent: 'right' }}>

--- a/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
+++ b/baby-gru/src/components/MoorhenPepflipsDifferenceMap.js
@@ -58,8 +58,8 @@ export const MoorhenPepflipsDifferenceMap = (props) => {
             const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)
             selectedMolecule.setAtomsDirty(true)
             selectedMolecule.redraw(props.glRef)
-            const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
-            document.dispatchEvent(mapUpdateEvent)
+            const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
+            document.dispatchEvent(scoresUpdateEvent)
         }
 
         if (args.every(arg => arg !== null)) {

--- a/baby-gru/src/components/MoorhenSimpleEditButton.js
+++ b/baby-gru/src/components/MoorhenSimpleEditButton.js
@@ -48,8 +48,8 @@ const MoorhenSimpleEditButton = forwardRef((props, buttonRef) => {
             }
             molecule.setAtomsDirty(true)
             molecule.redraw(props.glRef)
-            const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
-            document.dispatchEvent(mapUpdateEvent)
+            const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
+            document.dispatchEvent(scoresUpdateEvent)
             if (props.onExit) {
                 props.onExit(molecule, chosenAtom, result)
             }
@@ -656,8 +656,8 @@ export const MoorhenRotateTranslateZoneButton = (props) => {
         fragmentMolecule.current.delete(glRef)
         chosenMolecule.current.unhideAll(glRef)
         setShowAccept(false)
-        const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
-        document.dispatchEvent(mapUpdateEvent)
+        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
+        document.dispatchEvent(scoresUpdateEvent)
     }, [changeMolecules, glRef])
 
     const rejectTransform = useCallback(async (e) => {
@@ -944,8 +944,8 @@ export const MoorhenAddSimpleButton = (props) => {
         if (selectedMolecule) {
             await selectedMolecule.addLigandOfType(value, props.glRef.current.origin.map(coord => -coord), props.glRef)
             props.setSelectedButtonIndex(null)
-            const mapUpdateEvent = new CustomEvent("mapUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } })
-            document.dispatchEvent(mapUpdateEvent)    
+            const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } })
+            document.dispatchEvent(scoresUpdateEvent)    
         }
     }, [props.molecules, props.glRef])
 

--- a/baby-gru/src/components/MoorhenWebMG.js
+++ b/baby-gru/src/components/MoorhenWebMG.js
@@ -113,6 +113,15 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     const handleScoreUpdates = useCallback(async (e) => {
         if (e.detail?.modifiedMolecule !== null && connectedMolNo && connectedMolNo.molecule === e.detail.modifiedMolecule) {
             
+            await Promise.all(
+                props.maps.filter(map => connectedMolNo.uniqueMaps.includes(map.molNo)).map(map => {
+                    return map.doCootContour(glRef,
+                        ...glRef.current.origin.map(coord => -coord),
+                        map.mapRadius,
+                        map.contourLevel)
+                })
+            )
+            
             const currentScores = await props.commandCentre.current.cootCommand({
                 returnType: "r_factor_stats",
                 command: "get_r_factor_stats",
@@ -177,7 +186,7 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
             }
         } 
 
-    }, [props.commandCentre, connectedMolNo, scores, props.preferences.defaultUpdatingScores])
+    }, [props.commandCentre, connectedMolNo, scores, props.preferences.defaultUpdatingScores, glRef, props.maps])
 
     const handleDisconnectMaps = () => {
         scores.current = {}
@@ -294,9 +303,9 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     }, [handleConnectMaps]);
 
     useEffect(() => {
-        document.addEventListener("mapUpdate", handleScoreUpdates);
+        document.addEventListener("scoresUpdate", handleScoreUpdates);
         return () => {
-            document.removeEventListener("mapUpdate", handleScoreUpdates);
+            document.removeEventListener("scoresUpdate", handleScoreUpdates);
         };
 
     }, [handleScoreUpdates]);

--- a/baby-gru/src/utils/MoorhenUtils.js
+++ b/baby-gru/src/utils/MoorhenUtils.js
@@ -601,6 +601,7 @@ export const getNameLabel = (item) => {
                 overlay={
                     <Tooltip id="name-label-tooltip" 
                     style={{
+                        zIndex: 9999,
                         backgroundColor: 'rgba(0, 0, 0, 0.85)',
                         padding: '2px 10px',
                         color: 'white',


### PR DESCRIPTION
This fixes the issue where scores where out of step. The event `mapUpdate` has been renamed `scoreUpdate` and the only `mapUpdate` that involved change of origin has been refactored to use `originChange` instead.