### PR TITLE
Fix overlapping carousel controls

### DIFF
--- a/baby-gru/src/components/MoorhenButtonBar.js
+++ b/baby-gru/src/components/MoorhenButtonBar.js
@@ -88,13 +88,13 @@ export const MoorhenButtonBar = (props) => {
         let currentItem = []
 
         editButtons.forEach(button => {
-            currentItem.push(button)
             currentlyUsedWidth += buttonWidth
             if (currentlyUsedWidth >= maximumAllowedWidth) {
                 carouselItems.push(currentItem)
                 currentItem = []
                 currentlyUsedWidth = 0
             }
+            currentItem.push(button)
         })
         
         if (currentItem.length > 0) {

--- a/baby-gru/src/components/MoorhenContainer.css
+++ b/baby-gru/src/components/MoorhenContainer.css
@@ -10,6 +10,16 @@
     height: calc(100% - 10rem);
 }
 
+.carousel-control-next {
+  width: max(80px, 10vh) !important;
+  height: max(40px, 5vh) !important;
+}
+
+.carousel-control-prev {
+  width: max(80px, 10vh) !important;
+  height: max(40px, 5vh) !important;
+}
+
 .validation-plot-div{
     height: calc(100%);
 }


### PR DESCRIPTION
This fixes the issue where the carousel controls would sometimes overlap with the first half of the action buttons.