### PR TITLE
Several updates to cloud and extraFileMenus

### DIFF
--- a/baby-gru/cloud/MoorhenCloudApp.js
+++ b/baby-gru/cloud/MoorhenCloudApp.js
@@ -2,6 +2,7 @@ import { useRef, useState, useReducer, useContext, useEffect, useCallback } from
 import { historyReducer, initialHistoryState } from '../src/components/MoorhenHistoryMenu'
 import { PreferencesContext } from "../src/utils/MoorhenPreferences"
 import { MoorhenContainer } from "../src/components/MoorhenContainer"
+import { isDarkBackground } from '../src/WebGLgComponents/mgWebGL'
 
 const initialMoleculesState = []
 
@@ -152,6 +153,25 @@ export const MoorhenCloudApp = (props) => {
         }
     }, [maps])
 
+    useEffect(() => {
+        const redrawMolecules = async () => {
+            if (!props.viewOnly || molecules.length === 0 || glRef.current.background_colour === null) {
+                return
+            }
+            const newBackgroundIsDark = isDarkBackground(...glRef.current.background_colour)
+            await Promise.all(molecules.map(molecule => {
+                if (molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark) {
+                    molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
+                    molecule.setAtomsDirty(true)
+                    return molecule.redraw(glRef)
+                }
+                return new Promise.resolve()
+            }))
+        }
+
+        redrawMolecules()
+
+    }, [glRef.current?.background_colour]);
 
     return <MoorhenContainer {...collectedProps}/>
 }

--- a/baby-gru/cloud/MoorhenCloudApp.js
+++ b/baby-gru/cloud/MoorhenCloudApp.js
@@ -165,13 +165,30 @@ export const MoorhenCloudApp = (props) => {
                     molecule.setAtomsDirty(true)
                     return molecule.redraw(glRef)
                 }
-                return new Promise.resolve()
+                return Promise.resolve()
             }))
         }
 
         redrawMolecules()
 
-    }, [glRef.current?.background_colour]);
+    }, [glRef.current?.background_colour])
+
+    useEffect(() => {
+        if (!Object.keys(preferences).some(key => preferences[key] === null)) {
+            props.onChangePreferencesListener(
+                Object.keys(preferences).reduce((obj, key) => {
+                    if (key === 'isMounted') {
+                        // pass
+                    } else if (key === 'shortCuts') {
+                        obj[key] = JSON.parse(preferences[key])
+                    } else {
+                        obj[key] = preferences[key]
+                    }
+                    return obj
+                }, {})
+            )
+        }
+    }, [preferences])
 
     return <MoorhenContainer {...collectedProps}/>
 }

--- a/baby-gru/cloud/MoorhenCloudApp.js
+++ b/baby-gru/cloud/MoorhenCloudApp.js
@@ -3,6 +3,7 @@ import { historyReducer, initialHistoryState } from '../src/components/MoorhenHi
 import { PreferencesContext } from "../src/utils/MoorhenPreferences"
 import { MoorhenContainer } from "../src/components/MoorhenContainer"
 import { isDarkBackground } from '../src/WebGLgComponents/mgWebGL'
+import { MenuItem } from '@mui/material'
 
 const initialMoleculesState = []
 
@@ -72,6 +73,16 @@ export const MoorhenCloudApp = (props) => {
         showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
         setShowColourRulesToast, ...props
     }
+
+    const doExportCallback = useCallback(async () => {
+        let moleculePromises = molecules.map(molecule => {return molecule.getAtoms()})
+        let moleculeAtoms = await Promise.all(moleculePromises)
+        molecules.forEach((molecule, index) => props.exportCallback(molecule.name, moleculeAtoms[index].data.result.pdbData))
+    }, [props.exportCallback, molecules])
+
+    const exportMenuItem =  <MenuItem key={'export-cloud'} id='cloud-export-menu-item' variant="success" onClick={doExportCallback}>
+                                Export to CCP4 Cloud
+                            </MenuItem>
 
     const doContourIfDirty = async () => {
         if (isDirty.current) {
@@ -190,5 +201,5 @@ export const MoorhenCloudApp = (props) => {
         }
     }, [preferences])
 
-    return <MoorhenContainer {...collectedProps}/>
+    return <MoorhenContainer {...collectedProps} extraFileMenus={[exportMenuItem]}/>
 }

--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -226,7 +226,6 @@ export default class MoorhenWrapper {
               const newUnitCellParams = JSON.stringify(molecule.getUnitCellParams())
               if (oldUnitCellParams !== newUnitCellParams) {
                 molecule.centreOn(this.controls.glRef, null, true)
-              } else {
               }   
             })
         })  

--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -33,7 +33,9 @@ export default class MoorhenWrapper {
     this.inputFiles = null
     this.rootId = null
     this.preferences = null
+    this.cachedPreferences = null
     this.exportCallback = () => {}
+    this.exportPreferencesCallback = () => {}
     reportWebVitals()
     createModule()
   }
@@ -70,6 +72,27 @@ export default class MoorhenWrapper {
     this.exportCallback = callbackFunction
   }
 
+  addOnChangePreferencesListener(callbackFunction) {
+    this.exportPreferencesCallback = callbackFunction
+  }
+
+  onChangePreferencesListener(preferences) {
+    const objectKeys = ['shortCuts', 'defaultBackgroundColor', 'defaultUpdatingScores']
+    for (const key of Object.keys(this.cachedPreferences)) {
+      if (key === 'version') {
+        continue
+      } else if (!objectKeys.includes(key) && this.cachedPreferences[key] !== preferences[key]) {
+        this.exportPreferencesCallback(JSON.stringify(preferences))
+        this.cachedPreferences = preferences  
+        break
+      } else if (objectKeys.includes(key) && JSON.stringify(this.cachedPreferences[key]) !== JSON.stringify(preferences[key])) {
+        this.exportPreferencesCallback(JSON.stringify(preferences))
+        this.cachedPreferences = preferences  
+        break
+      }
+    }
+  }
+
   forwardControls(controls) {
     console.log('Fetched controls', {controls})
     this.controls = controls
@@ -98,29 +121,25 @@ export default class MoorhenWrapper {
     }
   }
 
-  async exportPreferences() {
-    const defaultPreferences = getDefaultValues()                
-    const responses = await Promise.all(
-      Object.keys(defaultPreferences).map(key => localforage.getItem(key))
-    )
-    let storedPrefereneces = {}
-    Object.keys(defaultPreferences).forEach((key, index) => storedPrefereneces[key] = responses[index])
-    return JSON.stringify(storedPrefereneces)
-  }
+  async importPreferences(newPreferences) {
+    const defaultPreferences = getDefaultValues()
+    let preferences
+    
+    if (newPreferences.version === defaultPreferences.version) {
+      preferences = newPreferences
+    } else {
+      preferences = defaultPreferences
+    }
 
-  async importPreferences(preferences) {
-    const storedVersion = await localforage.getItem('version')
-    const defaultPreferences = getDefaultValues()                
-
-    if (storedVersion === defaultPreferences.version) {
-      await Promise.all(Object.keys(preferences).map(key => {
+    await Promise.all(Object.keys(preferences).map(key => {
         if (key === 'shortCuts') {
           return localforage.setItem(key, JSON.stringify(preferences[key]))
         } else {
           return localforage.setItem(key, preferences[key])
         }
-      }))
-    }
+    }))
+
+    this.cachedPreferences = preferences
   }
 
   addStyleSheet() {
@@ -262,6 +281,7 @@ export default class MoorhenWrapper {
               forwardControls={this.forwardControls.bind(this)}
               disableFileUploads={true}
               exportCallback={this.exportCallback.bind(this)}
+              onChangePreferencesListener={this.onChangePreferencesListener.bind(this)}
               monomerLibraryPath={this.monomerLibrary}
               extraMenus={[]}
               viewOnly={this.workMode === 'view'}
@@ -274,7 +294,7 @@ export default class MoorhenWrapper {
 
   async start() {
     if (!this.preferences) {
-      this.preferences = JSON.stringify(getDefaultValues()   )
+      this.preferences = getDefaultValues()
     }
     await this.importPreferences(this.preferences)
 

--- a/baby-gru/cloud/MoorhenWrapper.js
+++ b/baby-gru/cloud/MoorhenWrapper.js
@@ -154,6 +154,7 @@ export default class MoorhenWrapper {
       console.log(`Error fetching data from url ${inputFile}`)
     } else {
       const newMap = new MoorhenMap(this.controls.commandCentre)
+      newMap.litLines = this.preferences.litLines
       return new Promise(async (resolve, reject) => {
         try {
           await newMap.loadToCootFromMtzURL(inputFile, mapName, selectedColumns)
@@ -174,6 +175,7 @@ export default class MoorhenWrapper {
       console.log(`Error fetching data from url ${inputFile}`)
     } else {
       const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.monomerLibrary)
+      newMolecule.setBackgroundColour(this.controls.glRef.current.background_colour)
       return new Promise(async (resolve, reject) => {
           try {
               await newMolecule.loadToCootFromURL(inputFile, molName)
@@ -271,9 +273,10 @@ export default class MoorhenWrapper {
   }
 
   async start() {
-    if (this.preferences) {
-      await this.importPreferences(this.preferences)
+    if (!this.preferences) {
+      this.preferences = JSON.stringify(getDefaultValues()   )
     }
+    await this.importPreferences(this.preferences)
 
     this.renderMoorhen()
     this.addStyleSheet()

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -22,8 +22,8 @@ export const MoorhenContainer = (props) => {
         backgroundColor, setBackgroundColor, currentDropdownId, setCurrentDropdownId,
         appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
         showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
-        setShowColourRulesToast, disableFileUploads, urlPrefix, viewOnly, extraMenus,
-        monomerLibraryPath, forwardControls
+        setShowColourRulesToast, disableFileUploads, urlPrefix, viewOnly, extraNavBarMenus,
+        monomerLibraryPath, forwardControls, extraFileMenus
     } = props
     
     const innerWindowMarginWidth = convertRemToPx(1)
@@ -240,8 +240,8 @@ export const MoorhenContainer = (props) => {
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, toastContent, 
         setToastContent, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, showToast, setShowToast,
         windowWidth, windowHeight, innerWindowMarginWidth, showColourRulesToast, timeCapsuleRef, setShowColourRulesToast, 
-        isDark, exportCallback, disableFileUploads, urlPrefix, viewOnly, extraMenus, monomerLibraryPath, moleculesRef, mapsRef,
-        ...preferences
+        isDark, exportCallback, disableFileUploads, urlPrefix, viewOnly, extraNavBarMenus, monomerLibraryPath, moleculesRef, 
+        extraFileMenus, mapsRef, ...preferences
     }
 
     return <> 
@@ -315,6 +315,7 @@ MoorhenContainer.defaultProps = {
     monomerLibraryPath: './baby-gru/monomers',
     exportCallback: null,
     disableFileUploads: false,
-    extraMenus: [],
+    extraNavBarMenus: [],
+    extraFileMenus: [],
     viewOnly: false
 }

--- a/baby-gru/src/components/MoorhenFileMenu.js
+++ b/baby-gru/src/components/MoorhenFileMenu.js
@@ -46,12 +46,6 @@ export const MoorhenFileMenu = (props) => {
         return newMolecule.loadToCootFromFile(file)
     }
 
-    const doExportCallback = async () => {
-        let moleculePromises = props.molecules.map(molecule => {return molecule.getAtoms()})
-        let moleculeAtoms = await Promise.all(moleculePromises)
-        props.molecules.forEach((molecule, index) => props.exportCallback(molecule.name, moleculeAtoms[index].data.result.pdbData))
-    }
-
     const fetchFiles = () => {
         if (remoteSource === "PDBe") {
             fetchFilesFromEBI()
@@ -485,11 +479,7 @@ export const MoorhenFileMenu = (props) => {
                     
                     <MoorhenBackupsMenuItem {...menuItemProps} setShowBackupsModal={setShowBackupsModal} loadSessionJSON={loadSessionJSON} />
 
-                    {props.exportCallback &&
-                        <MenuItem id='cloud-export-menu-item' variant="success" onClick={doExportCallback}>
-                            Export to CCP4 Cloud
-                        </MenuItem>
-                    }
+                    {props.extraFileMenus && props.extraFileMenus.map( menu => menu)}
                     
                     <hr></hr>
 

--- a/baby-gru/src/components/MoorhenNavBar.js
+++ b/baby-gru/src/components/MoorhenNavBar.js
@@ -33,7 +33,7 @@ export const MoorhenNavBar = forwardRef((props, ref) => {
                         <MoorhenHistoryMenu dropdownId="History" {...collectedProps} />
                         <MoorhenPreferencesMenu dropdownId="Preferences" {...collectedProps} />
                         <MoorhenHelpMenu dropdownId="Help" {...collectedProps}/>
-                        {props.extraMenus && props.extraMenus.map(menu=>menu)}
+                        {props.extraNavBarMenus && props.extraNavBarMenus.map(menu => menu)}
                     </Nav>
                 </Navbar.Collapse>
                 <Nav className="justify-content-right">

--- a/baby-gru/src/utils/MoorhenMap.js
+++ b/baby-gru/src/utils/MoorhenMap.js
@@ -11,7 +11,7 @@ export function MoorhenMap(commandCentre) {
     this.webMGContour = false
     this.cootContour = true
     this.displayObjects = { Coot: [] }
-    this.litLines = true
+    this.litLines = false
     this.solid = false
     this.alpha = 1.0
     this.isDifference = false


### PR DESCRIPTION
This update includes:
- `props.extraMenus` is renamed to `extraNavBarMenus` and `props.extraFileMenus` is added. Callback to export to cloud uses this new props.
- Redraw molecules if background changes in view only mode
- Change default lit lines to false in view only mode
- Enable export of preferences to cloud