### PR TITLE
Update symmetry slider to use recursion

### DIFF
--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -623,9 +623,27 @@ export const MoorhenMoleculeBondSettingsMenuItem = (props) => {
 export const MoorhenMoleculeSymmetrySettingsMenuItem = (props) => {
     const [symmetryRadius, setSymmetryRadius] = useState(25.0)
     const [symmetryOn, setSymmetryOn] = useState(false)
+    const isDirty = useRef(false)
+    const busyDrawing = useRef(false)
+
+    const drawSymmetryIfDirty = () => {
+        if (isDirty.current) {
+            busyDrawing.current = true
+            isDirty.current = false
+            props.molecule.drawSymmetry(props.glRef)
+            .then(_ => {
+                busyDrawing.current = false
+                drawSymmetryIfDirty()
+            })
+        }
+    }
 
     useEffect(() => {
-        props.molecule.setSymmetryRadius(symmetryRadius, props.glRef)
+        isDirty.current = true
+        props.molecule.symmetryRadius = symmetryRadius
+        if (!busyDrawing.current) {
+            drawSymmetryIfDirty()
+        }
     }, [symmetryRadius])
 
     useEffect(() => {

--- a/baby-gru/src/utils/MoorhenMolecule.js
+++ b/baby-gru/src/utils/MoorhenMolecule.js
@@ -92,14 +92,14 @@ MoorhenMolecule.prototype.replaceModelWithFile = async function (glRef, fileUrl,
     return Promise.reject(cootResponse.data.result.status)
 }
 
-MoorhenMolecule.prototype.toggleSymmetry = async function (glRef) {
+MoorhenMolecule.prototype.toggleSymmetry = function (glRef) {
     this.symmetryOn = !this.symmetryOn;
-    this.drawSymmetry(glRef)
+    return this.drawSymmetry(glRef)
 }
 
-MoorhenMolecule.prototype.setSymmetryRadius = async function (radius, glRef) {
+MoorhenMolecule.prototype.setSymmetryRadius = function (radius, glRef) {
     this.symmetryRadius = radius
-    this.drawSymmetry(glRef)
+    return this.drawSymmetry(glRef)
 }
 
 MoorhenMolecule.prototype.drawSymmetry = async function (glRef) {


### PR DESCRIPTION
After this update, the symmetry radius slider uses a recursive function to only draw the latest value of the slider.