### PR TITLE
Overload states and refs of MoorhenContainer

### DIFF
--- a/baby-gru/cloud/src/components/MoorhenCloudApp.js
+++ b/baby-gru/cloud/src/components/MoorhenCloudApp.js
@@ -1,6 +1,5 @@
 import { useRef, useState, useReducer, useContext, useEffect, useCallback } from 'react'
 import { MenuItem } from '@mui/material'
-import { historyReducer, initialHistoryState } from '../../../src/components/MoorhenHistoryMenu'
 import { PreferencesContext } from "../../../src/utils/MoorhenPreferences"
 import { MoorhenContainer } from "../../../src/components/MoorhenContainer"
 import { isDarkBackground } from '../../../src/WebGLgComponents/mgWebGL'
@@ -32,28 +31,17 @@ export const MoorhenCloudApp = (props) => {
     const moleculesRef = useRef(null)
     const mapsRef = useRef(null)
     const activeMapRef = useRef(null)
-    const consoleDivRef = useRef(null)
     const lastHoveredAtom = useRef(null)
-    const prevActiveMoleculeRef = useRef(null)
     const isDirty = useRef(false)
     const busyContouring = useRef(false)
     const preferences = useContext(PreferencesContext)
     const [activeMap, setActiveMap] = useState(null)
-    const [activeMolecule, setActiveMolecule] = useState(null)
     const [hoveredAtom, setHoveredAtom] = useState({ molecule: null, cid: null })
-    const [consoleMessage, setConsoleMessage] = useState("")
-    const [cursorStyle, setCursorStyle] = useState("default")
     const [busy, setBusy] = useState(false)
-    const [windowWidth, setWindowWidth] = useState(window.innerWidth)
-    const [windowHeight, setWindowHeight] = useState(window.innerHeight)
-    const [commandHistory, dispatchHistoryReducer] = useReducer(historyReducer, initialHistoryState)
     const [molecules, changeMolecules] = useReducer(itemReducer, initialMoleculesState)
     const [maps, changeMaps] = useReducer(itemReducer, initialMapsState)
     const [backgroundColor, setBackgroundColor] = useState([1, 1, 1, 1])
-    const [currentDropdownId, setCurrentDropdownId] = useState(-1)
-    const [appTitle, setAppTitle] = useState('Moorhen')
     const [cootInitialized, setCootInitialized] = useState(false)
-    const [theme, setTheme] = useState("flatly")
     const [showToast, setShowToast] = useState(false)
     const [toastContent, setToastContent] = useState("")
     const [showColourRulesToast, setShowColourRulesToast] = useState(false)
@@ -74,16 +62,11 @@ export const MoorhenCloudApp = (props) => {
 
     const collectedProps = {
         ...props, glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, 
-        activeMapRef, consoleDivRef, lastHoveredAtom, prevActiveMoleculeRef, 
-        preferences, activeMap, setActiveMap, activeMolecule, setActiveMolecule,
-        consoleMessage, setConsoleMessage, cursorStyle, setCursorStyle, busy, setBusy,
-        windowWidth, setWindowWidth, windowHeight, setWindowHeight, commandHistory, 
-        dispatchHistoryReducer, molecules, changeMolecules, maps, changeMaps, 
-        backgroundColor, setBackgroundColor, currentDropdownId, setCurrentDropdownId,
-        appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
+        activeMapRef, lastHoveredAtom, preferences, activeMap, setActiveMap,
+        busy, setBusy, molecules, changeMolecules, maps, changeMaps, 
+        backgroundColor, setBackgroundColor, cootInitialized, setCootInitialized,
         showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
         setShowColourRulesToast, hoveredAtom, setHoveredAtom,
-        
     }
 
     const doExportCallback = useCallback(async () => {

--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -88,13 +88,10 @@ export const MoorhenContainer = (props) => {
         setShowColourRulesToast: setInnerShowColourRulesToast 
     }
 
-    const getStates = () => {
-        const result = {}
-        Object.keys(innerStatesMap).forEach(key => {
-            result[key] = props[key] ? props[key] : innerStatesMap[key]
-        })
-        return result
-    }
+    const states = {}
+    Object.keys(innerStatesMap).forEach(key => {
+        states[key] = props[key] ? props[key] : innerStatesMap[key]
+    })
 
     const { glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef,
         consoleDivRef, lastHoveredAtom, prevActiveMoleculeRef, preferences, activeMap, 
@@ -106,15 +103,13 @@ export const MoorhenContainer = (props) => {
         appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
         showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
         setShowColourRulesToast
-    } = getStates(innerStatesMap, props)
+    } = states
 
     const {
         disableFileUploads, urlPrefix, extraNavBarMenus, exportCallback, viewOnly, devMode, 
         monomerLibraryPath, forwardControls, extraFileMenuItems
     } = props
     
-    const innerWindowMarginWidth = convertRemToPx(1)
-
     const setWindowDimensions = () => {
         setWindowWidth(window.innerWidth)
         setWindowHeight(window.innerHeight)
@@ -337,9 +332,9 @@ export const MoorhenContainer = (props) => {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, toastContent, 
         setToastContent, currentDropdownId, setCurrentDropdownId, hoveredAtom, setHoveredAtom, showToast, setShowToast,
-        windowWidth, windowHeight, innerWindowMarginWidth, showColourRulesToast, timeCapsuleRef, setShowColourRulesToast, 
-        isDark, exportCallback, disableFileUploads, urlPrefix, viewOnly, extraNavBarMenus, monomerLibraryPath, moleculesRef, 
-        extraFileMenuItems, mapsRef, devMode, ...preferences
+        windowWidth, windowHeight, showColourRulesToast, timeCapsuleRef, setShowColourRulesToast, isDark, exportCallback,
+        disableFileUploads, urlPrefix, viewOnly, extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, 
+        mapsRef, devMode, ...preferences
     }
 
     return <> 


### PR DESCRIPTION
 @martinemnoble1 
As requested, after this update it is possible to overload the states and references defined in `MoorhenContainer`.