### PR TITLE
Multiple fixes for ligand features

### DIFF
--- a/baby-gru/cloud/src/components/MoorhenCloudApp.js
+++ b/baby-gru/cloud/src/components/MoorhenCloudApp.js
@@ -76,7 +76,7 @@ export const MoorhenCloudApp = (props) => {
     }, [props.exportCallback, molecules])
 
     const exportMenuItem =  <MenuItem key={'export-cloud'} id='cloud-export-menu-item' variant="success" onClick={doExportCallback}>
-                                Export to CCP4 Cloud
+                                Save current model
                             </MenuItem>
 
     const doContourIfDirty = async () => {

--- a/baby-gru/src/components/MoorhenChainSelect.js
+++ b/baby-gru/src/components/MoorhenChainSelect.js
@@ -3,10 +3,11 @@ import { Form, FormSelect } from "react-bootstrap";
 
 export const MoorhenChainSelect = forwardRef((props, selectRef) => {
     
-    const handleChange = (newChain) => {
+    const handleChange = (evt) => {
         if (props.onChange) {
-            props.onChange(newChain)
+            props.onChange(evt)
         }
+        if(selectRef) selectRef.current.value = evt.target.value
     }
 
     const getChainOptions = (selectedCoordMolNo) => {

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -301,7 +301,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
     const ligandMoleculeRef = useRef(null)
     const mapSelectRef = useRef(null)
     const useConformersRef = useRef(false)
-    const conformerCountRef = useRef(10)
+    const conformerCountRef = useRef(0)
     const [useConformers, setUseConformers] = useState(false)
     const [conformerCount, setConformerCount] = useState(10)
 
@@ -309,7 +309,8 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
         <MoorhenMapSelect {...props} label="Map" allowAny={false} ref={mapSelectRef} />
         <MoorhenMoleculeSelect {...props} label="Protein molecule" allowAny={false} ref={intoMoleculeRef} />
         <MoorhenMoleculeSelect {...props} label="Ligand molecule" allowAny={false} ref={ligandMoleculeRef} />
-        <Form.Check
+        {/** FIXME: This remains unavailable until the thread pool exhausted issue is fixed
+         <Form.Check
             style={{margin: '0.5rem'}} 
             type="switch"
             checked={useConformers}
@@ -317,7 +318,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
                 useConformersRef.current = !useConformers
                 setUseConformers(!useConformers)
             }}
-            label="Use conformers"/>
+            label="Use conformers"/>*/}
         {useConformers &&
         <Form.Group>
         <TextField

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -2094,10 +2094,10 @@ export const MoorhenCentreOnLigandMenuItem = (props) => {
             key='centre-on-ligand-menu-item'
             id='centre-on-ligand-menu-item'
             popoverContent={
+                molTreeData.length > 0 ?
                 <Tree treeData={molTreeData}
                     onSelect={async (selectedKeys, e) => {
                         if (e.node.type === "ligand") {
-
                             const selAtoms = await e.node.molecule.gemmiAtomsForCid(e.node.title)
                             const reducedValue = selAtoms.reduce(
                                 (accumulator, currentValue) => {
@@ -2116,9 +2116,12 @@ export const MoorhenCentreOnLigandMenuItem = (props) => {
                     }}
                 >
                 </Tree>
+                :
+                <span>No ligands...</span>
             }
             menuItemText="Centre on ligand..."
             setPopoverIsShown={props.setPopoverIsShown}
+            showOkButton={false}
         />
     </>
 }

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1174,7 +1174,12 @@ export const MoorhenImportDictionaryMenuItem = (props) => {
             returnType: 'str_str_pair'
         }, true)
         const result = response.data.result.result.second
-        return handleFileContent(result)
+        if (result) {
+            return handleFileContent(result)
+        } else {
+            console.log('Error creating molecule... Wrong SMILES?')
+            props.commandCentre.current.extendConsoleMessage('Error creating molecule... Wrong SMILES?')
+        }
     }
 
     const onCompleted = useCallback(async () => {

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -225,10 +225,11 @@ export const MoorhenGetMonomerMenuItem = (props) => {
             newMolecule.name = newTlc
             newMolecule.setBackgroundColour(props.glRef.current.background_colour)
             newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
-
-            const fromMolecule = props.molecules.find(molecule => molecule.molNo === fromMolNo)
-            const ligandDict = fromMolecule.getDict(newTlc)
-            await newMolecule.addDict(ligandDict)
+            if (typeof fromMolecule !== 'undefined') {
+                const fromMolecule = props.molecules.find(molecule => molecule.molNo === fromMolNo)
+                const ligandDict = fromMolecule.getDict(newTlc)
+                await newMolecule.addDict(ligandDict)    
+            }
             await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
             props.changeMolecules({ action: "Add", item: newMolecule })
         } else {

--- a/baby-gru/src/components/MoorhenMenuItem.js
+++ b/baby-gru/src/components/MoorhenMenuItem.js
@@ -1,7 +1,7 @@
-import { MenuItem } from "@mui/material";
+import { MenuItem, TextField } from "@mui/material";
 import { CheckOutlined, CloseOutlined } from "@mui/icons-material";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Modal, OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown, Stack, Placeholder } from "react-bootstrap";
+import { OverlayTrigger, Popover, PopoverBody, PopoverHeader, Form, InputGroup, Button, FormSelect, Row, Col, SplitButton, Dropdown, Stack, Placeholder } from "react-bootstrap";
 import { SketchPicker } from "react-color";
 import { MoorhenMtzWrapper, readTextFile, readDataFile } from "../utils/MoorhenUtils";
 import { MoorhenMap } from "../utils/MoorhenMap";
@@ -301,15 +301,49 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
     const intoMoleculeRef = useRef(null)
     const ligandMoleculeRef = useRef(null)
     const mapSelectRef = useRef(null)
+    const useConformersRef = useRef(false)
+    const conformerCountRef = useRef(10)
+    const [useConformers, setUseConformers] = useState(false)
+    const [conformerCount, setConformerCount] = useState(10)
 
     const panelContent = <>
         <MoorhenMapSelect {...props} label="Map" allowAny={false} ref={mapSelectRef} />
         <MoorhenMoleculeSelect {...props} label="Protein molecule" allowAny={false} ref={intoMoleculeRef} />
         <MoorhenMoleculeSelect {...props} label="Ligand molecule" allowAny={false} ref={ligandMoleculeRef} />
+        <Form.Check
+            style={{margin: '0.5rem'}} 
+            type="switch"
+            checked={useConformers}
+            onChange={() => { 
+                useConformersRef.current = !useConformers
+                setUseConformers(!useConformers)
+            }}
+            label="Use conformers"/>
+        {useConformers &&
+        <Form.Group>
+        <TextField
+                style={{margin: '0.5rem'}} 
+                id='conformer-count'
+                label='No. of conformers'
+                type='number'
+                variant="standard"
+                error={isNaN(parseInt(conformerCount)) || parseInt(conformerCount) < 0 || parseInt(conformerCount) === Infinity}
+                value={conformerCount}
+                onChange={(evt) => {
+                    conformerCountRef.current = evt.target.value
+                    setConformerCount(evt.target.value)
+                }}
+            />
+        </Form.Group>
+        }
     </>
 
 
     const onCompleted = () => {
+        if (useConformersRef.current && (isNaN(parseInt(conformerCountRef.current)) || parseInt(conformerCountRef.current) < 0 || parseInt(conformerCountRef.current) === Infinity)) {
+            console.log('Unable to parse conformer count into a valid int...')
+            return
+        }
         props.commandCentre.current.cootCommand({
             returnType: 'int_array',
             command: 'fit_ligand_right_here',
@@ -318,7 +352,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props) => {
                 parseInt(mapSelectRef.current.value),
                 parseInt(ligandMoleculeRef.current.value),
                 ...props.glRef.current.origin.map(coord => -coord),
-                1., false, 1
+                1., useConformersRef.current, parseInt(conformerCountRef.current)
             ]
 
         }, true)

--- a/baby-gru/src/components/MoorhenMoleculeSelect.js
+++ b/baby-gru/src/components/MoorhenMoleculeSelect.js
@@ -4,9 +4,12 @@ import { Form, FormSelect } from "react-bootstrap";
 export const MoorhenMoleculeSelect = forwardRef((props, selectRef) => {
     return <Form.Group style={{ width: props.width, margin: '0.5rem', height:props.height }}>
         <Form.Label>{props.label}</Form.Label>
-        <FormSelect size="sm" ref={selectRef} defaultValue={-999999} onChange={(val) => {
+        <FormSelect size="sm" ref={selectRef} defaultValue={-999999} onChange={(evt) => {
             if (props.onChange) {
-                props.onChange(val)
+                props.onChange(evt)
+            }
+            if(selectRef) {
+                selectRef.current.value = evt.target.value
             }
         }}>
             {props.allowAny && <option value={-999999} key={-999999}>Any molecule</option>}


### PR DESCRIPTION
This update fixes several issues:
- Empty menu in "centre on ligand" when there are no ligands
- Grey balls displayed in place of a ligand when using rotate translate and copy fragment
- SMILES with wrong format crash the app
- Grey ball ligands when importing a dictionary and not merging to a given molecule
- Import ligand will add the dictionary to all molecules instead of just the selected one
This update also includes UI elements for using conformers when using "Fit ligand here", but they will remain hidden until the "thread pool exhausted" issue is resolved.