### PR TITLE
Updated meta data to better describe Moorhen

### DIFF
--- a/baby-gru/cloud/webcoot.html
+++ b/baby-gru/cloud/webcoot.html
@@ -7,7 +7,7 @@
   <link rel="icon"             href="./favicon.ico"/>
   <meta name="viewport"        content="width=device-width,initial-scale=1"/>
   <meta name="theme-color"     content="#000000"/>
-  <meta name="description"     content="Web site created using create-react-app"/>
+  <meta name="description"     content="Moorhen is a molecular graphics web application based on the Coot desktop program."/>
   <link rel="apple-touch-icon" href="./public/logo192.png"/>
   <link rel="manifest"         href="./manifest.json"/>
 </head>

--- a/baby-gru/public/index.html
+++ b/baby-gru/public/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Web site created using create-react-app" />
+  <meta name="description" content="Moorhen is a molecular graphics web application based on the Coot desktop program." />
   <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
   <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/react-app/public/index.html
+++ b/react-app/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Moorhen is a molecular graphics web application based on the Coot desktop program."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
The metadata displayed on Google underneath a search of Moorhen shows 'Web site created using create-react-app.', I have changed this to metadata to 'Moorhen is a molecular graphics web application based on the Coot desktop program.' 

