### PR TITLE
Only recontour maps on mouse up and other improvements

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.js
+++ b/baby-gru/src/components/MoorhenContainer.js
@@ -384,8 +384,6 @@ export const MoorhenContainer = (props) => {
                         backgroundColor={backgroundColor}
                         setBackgroundColor={setBackgroundColor}
                         isDark={isDark}
-                        atomLabelDepthMode={preferences.atomLabelDepthMode}
-                        clipCap={preferences.clipCap}
                         onAtomHovered={onAtomHovered}
                         onKeyPress={onKeyPress}
                         hoveredAtom={hoveredAtom}
@@ -397,12 +395,7 @@ export const MoorhenContainer = (props) => {
                         urlPrefix={urlPrefix}
                         activeMap={activeMap}
                         viewOnly={viewOnly}
-                        drawInteractions={preferences.drawInteractions}
-                        doPerspectiveProjection={preferences.doPerspectiveProjection}
-                        useOffScreenBuffers={preferences.useOffScreenBuffers}
-                        doShadowDepthDebug={preferences.doShadowDepthDebug}
                         extraDraggableModals={extraDraggableModals}
-                        doShadow={preferences.doShadow}
                     />
                 </div>
                 {!viewOnly && <MoorhenButtonBar {...collectedProps} />}

--- a/baby-gru/src/components/button/MoorhenMoleculeCardButtonBar.js
+++ b/baby-gru/src/components/button/MoorhenMoleculeCardButtonBar.js
@@ -96,13 +96,8 @@ export const MoorhenMoleculeCardButtonBar = (props) => {
             expanded: null
         },
         12: {
-            label: 'Rotate/Translate molecule',
-            compressed: () => { return (<MoorhenRotateTranslateMoleculeMenuItem key={12} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} changeMolecules={props.changeMolecules} glRef={props.glRef}/>) },
-            expanded: null
-        },
-        13: {
             label: 'Symmetry settings',
-            compressed: () => { return (<MoorhenMoleculeSymmetrySettingsMenuItem key={13} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} glRef={props.glRef}/>) },
+            compressed: () => { return (<MoorhenMoleculeSymmetrySettingsMenuItem key={12} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} glRef={props.glRef}/>) },
             expanded: null
         },
     }

--- a/baby-gru/src/components/menu-item/MoorhenMenuItem.js
+++ b/baby-gru/src/components/menu-item/MoorhenMenuItem.js
@@ -295,7 +295,7 @@ export const MoorhenSharpenBlurMapMenuItem = (props) => {
     }
 
     return <MoorhenMenuItem
-        id='sharpen-blur-map'
+        id='sharpen-blur-map-menu-item'
         popoverContent={panelContent}
         menuItemText="Sharpen/Blur map..."
         onCompleted={onCompleted}
@@ -604,6 +604,7 @@ export const MoorhenBackupPreferencesMenuItem = (props) => {
         </>
 
     return <MoorhenMenuItem
+        id="auto-backup-settings-menu-item"
         popoverPlacement='right'
         popoverContent={panelContent}
         menuItemText={"Automatic backup settings..."}
@@ -662,6 +663,7 @@ export const MoorhenScoresToastPreferencesMenuItem = (props) => {
         </>
 
     return <MoorhenMenuItem
+        id="updating-maps-scores-options-menu-item"
         popoverPlacement='right'
         popoverContent={panelContent}
         menuItemText={"Options for scores when updating maps..."}
@@ -1502,6 +1504,7 @@ export const MoorhenBackupsMenuItem = (props) => {
     </>
 
     return <MoorhenMenuItem
+        id="recover-backup-menu-item"
         disabled={props.disabled}
         showOkButton={false}
         popoverContent={panelContent}
@@ -1609,6 +1612,7 @@ export const MoorhenImportFSigFMenuItem = (props) => {
     </>
 
     return <MoorhenMenuItem
+        id="connect-molecule-and-map-menu-item"
         popoverContent={panelContent}
         menuItemText="Connect mol. and map for updating..."
         onCompleted={onCompleted}
@@ -2424,7 +2428,7 @@ export const MoorhenMapMaskingMenuItem = (props) => {
     }, [commandCentre, maps, changeMaps])
 
     return <MoorhenMenuItem
-        id='mask-map'
+        id='mask-map-menu-item'
         popoverContent={panelContent}
         menuItemText="Map masking..."
         onCompleted={onCompleted}

--- a/baby-gru/src/components/misc/MoorhenSearchBar.js
+++ b/baby-gru/src/components/misc/MoorhenSearchBar.js
@@ -101,6 +101,21 @@ export const MoorhenSearchBar = (props) => {
             {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
             {type: 'click', elementId: 'delete-everything-menu-item', condition: true}
         ]},
+        {label: "Superpose structures", actions: [
+            {type: 'click', elementId: 'calculate-nav-dropdown', condition: props.currentDropdownId !== "Calculate"}, 
+            {type: 'setValue', newValue:'Calculate', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Calculate"},
+            {type: 'click', elementId: 'superpose-models-menu-item', condition: true}
+        ]},
+        {label: "Ligand builder", actions: [
+            {type: 'click', elementId: 'calculate-nav-dropdown', condition: props.currentDropdownId !== "Calculate"}, 
+            {type: 'setValue', newValue:'Calculate', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Calculate"},
+            {type: 'click', elementId: 'ligand-builder-menu-item', condition: true}
+        ]},
+        {label: "Scripting", actions: [
+            {type: 'click', elementId: 'calculate-nav-dropdown', condition: props.currentDropdownId !== "Calculate"}, 
+            {type: 'setValue', newValue:'Calculate', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Calculate"},
+            {type: 'click', elementId: 'interactive-scripting-menu-item', condition: true}
+        ]},
         {label: "Difference Map Peaks", actions: [
             {type: 'click', condition: true, elementId: 'open-sidebar-button'}, 
             {type: 'click', condition: dropdownIsClosed('validation-tools-collapse'), elementId: 'validation-tools-dropdown'},
@@ -143,6 +158,26 @@ export const MoorhenSearchBar = (props) => {
             {type: 'setValue', newValue:'Ligand', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Ligand"},
             {type: 'click', elementId: 'get-monomer-menu-item', condition: true}
         ]},
+        {label: "Ligand from SMILES", actions: [
+            {type: 'click', elementId: 'ligand-nav-dropdown', condition: props.currentDropdownId !== "Ligand"}, 
+            {type: 'setValue', newValue:'Ligand', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Ligand"},
+            {type: 'click', elementId: 'smiles-to-ligand-menu-item', condition: true}
+        ]},
+        {label: "Fit ligand here", actions: [
+            {type: 'click', elementId: 'ligand-nav-dropdown', condition: props.currentDropdownId !== "Ligand"}, 
+            {type: 'setValue', newValue:'Ligand', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Ligand"},
+            {type: 'click', elementId: 'fit-ligand-right-here-menu-item', condition: true}
+        ]},
+        {label: "Centre on ligand", actions: [
+            {type: 'click', elementId: 'ligand-nav-dropdown', condition: props.currentDropdownId !== "Ligand"}, 
+            {type: 'setValue', newValue:'Ligand', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Ligand"},
+            {type: 'click', elementId: 'centre-on-ligand-menu-item', condition: true}
+        ]},
+        {label: "Change molecule colours", actions: [
+            {type: 'click', elementId: 'view-nav-dropdown', condition: props.currentDropdownId !== "View"}, 
+            {type: 'setValue', newValue:'View', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "View"},
+            {type: 'click', elementId: 'change-molecule-colours-menu-item', condition: true}
+        ]},
         {label: "Go to cid", actions: [
             {type: 'click', elementId: 'edit-nav-dropdown', condition: props.currentDropdownId !== "Edit"}, 
             {type: 'setValue', newValue:'Edit', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Edit"},
@@ -158,6 +193,21 @@ export const MoorhenSearchBar = (props) => {
             {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
             {type: 'click', elementId: 'upload-coordinates-form', condition: true}
         ]},
+        {label: "Updating maps", actions: [
+            {type: 'click', elementId: 'file-nav-dropdown', condition: props.currentDropdownId !== "File"},
+            {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
+            {type: 'click', elementId: 'connect-molecule-and-map-menu-item', condition: true}
+        ]},
+        {label: "Recover backup", actions: [
+            {type: 'click', elementId: 'file-nav-dropdown', condition: props.currentDropdownId !== "File"},
+            {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
+            {type: 'click', elementId: 'recover-backup-menu-item', condition: true}
+        ]},
+        {label: "Auto open mtz", actions: [
+            {type: 'click', elementId: 'file-nav-dropdown', condition: props.currentDropdownId !== "File"},
+            {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
+            {type: 'click', elementId: 'auto-open-mtz-menu-item', condition: true}
+        ]},
         {label: "Load Tutorial Data", actions: [
             {type: 'click', elementId: 'file-nav-dropdown', condition: props.currentDropdownId !== "File"},
             {type: 'setValue', newValue:'File', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "File"},
@@ -167,6 +217,31 @@ export const MoorhenSearchBar = (props) => {
             {type: 'click', elementId: 'edit-nav-dropdown', condition: props.currentDropdownId !== "Edit"},
             {type: 'setValue', newValue:'Edit', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Edit"},
             {type: 'click', elementId: 'merge-molecules-menu-item', condition: true}
+        ]},
+        {label: "Map blurring", actions: [
+            {type: 'click', elementId: 'cryo-nav-dropdown', condition: props.currentDropdownId !== "Cryo"},
+            {type: 'setValue', newValue:'Cryo', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Cryo"},
+            {type: 'click', elementId: 'sharpen-blur-map-menu-item', condition: true}
+        ]},
+        {label: "Map masking", actions: [
+            {type: 'click', elementId: 'cryo-nav-dropdown', condition: props.currentDropdownId !== "Cryo"},
+            {type: 'setValue', newValue:'Cryo', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Cryo"},
+            {type: 'click', elementId: 'mask-map-menu-item', condition: true}
+        ]},
+        {label: "Backup settings", actions: [
+            {type: 'click', elementId: 'preferences-nav-dropdown', condition: props.currentDropdownId !== "Preferences"},
+            {type: 'setValue', newValue:'Preferences', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Preferences"},
+            {type: 'click', elementId: 'auto-backup-settings-menu-item', condition: true}
+        ]},
+        {label: "Updating maps score options", actions: [
+            {type: 'click', elementId: 'preferences-nav-dropdown', condition: props.currentDropdownId !== "Preferences"},
+            {type: 'setValue', newValue:'Preferences', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Preferences"},
+            {type: 'click', elementId: 'updating-maps-scores-options-menu-item', condition: true}
+        ]},
+        {label: "Configure shortcuts", actions: [
+            {type: 'click', elementId: 'preferences-nav-dropdown', condition: props.currentDropdownId !== "Preferences"},
+            {type: 'setValue', newValue:'Preferences', valueSetter: props.setCurrentDropdownId, condition: props.currentDropdownId !== "Preferences"},
+            {type: 'click', elementId: 'configure-shortcuts-menu-item', condition: true}
         ]},
         {label: "Model Validation", actions: [
             {type: 'click', condition: true, elementId: 'open-sidebar-button'}, 
@@ -212,10 +287,6 @@ export const MoorhenSearchBar = (props) => {
         {label: "Show Console", actions: [
             {type: 'click', condition: !props.showSideBar , elementId: 'show-sidebar-button'}, 
             {type: 'click', condition: props.consoleBodyHeight === 0, elementId: 'console-accordion-button'},
-        ]},
-        {label: "Show controls", actions: [
-            {type: 'click', condition: true, elementId: 'open-sidebar-button'}, 
-            {type: 'click', condition: dropdownIsClosed('console-collapse'), elementId: 'console-dropdown'},
         ]},
         {label: "Show models and maps", actions: [
             {type: 'click', condition: true, elementId: 'open-sidebar-button'}, 

--- a/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.js
+++ b/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.js
@@ -20,13 +20,13 @@ export const MoorhenCalculateMenu = (props) => {
             show={props.currentDropdownId === props.dropdownId}
             onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId(-1) }}>
             <MoorhenSuperposeMenuItem key="superpose_structures" {...menuItemProps} />
-            <MenuItem onClick={() => setShowLigandBuilder(true)}>
+            <MenuItem id="ligand-builder-menu-item" onClick={() => setShowLigandBuilder(true)}>
                 Ligand builder...
             </MenuItem>
             {props.allowScripting && 
             <>
                 <MoorhenLoadScriptMenuItem {...menuItemProps} />
-                <MenuItem onClick={() => { setShowCodeEditor(true) }}>Interactive scripting...</MenuItem>
+                <MenuItem id="interactive-scripting-menu-item" onClick={() => { setShowCodeEditor(true) }}>Interactive scripting...</MenuItem>
             </>
             }
             {props.extraCalculateMenuItems && props.extraCalculateMenuItems.map( menu => menu)}

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.js
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.js
@@ -137,7 +137,7 @@ export const MoorhenPreferencesMenu = (props) => {
                         setDefaultBondSmoothness={setDefaultBondSmoothness}
                         setPopoverIsShown={setPopoverIsShown}
                     />
-                    <MenuItem variant="success" onClick={() => setShowModal(true)} id='configure-shortcuts-menu-item' style={{marginTop:'0rem'}}>
+                    <MenuItem id="configure-shortcuts-menu-item" variant="success" onClick={() => setShowModal(true)} style={{marginTop:'0rem'}}>
                         Configure shortcuts...
                     </MenuItem>
                     <MoorhenShortcutConfigModal showModal={showModal} setShowModal={setShowModal} setShortCuts={props.setShortCuts} shortCuts={JSON.parse(props.shortCuts)}/>

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.js
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.js
@@ -68,7 +68,7 @@ export const MoorhenViewMenu = (props) => {
                     <MoorhenBackgroundColorMenuItem {...menuItemProps} />
                     <MoorhenClipFogMenuItem {...menuItemProps} />
                     <MoorhenLightingMenuItem {...menuItemProps} />
-                    <MenuItem onClick={() => {
+                    <MenuItem id="change-molecule-colours-menu-item" onClick={() => {
                         props.setShowColourRulesToast(true)
                         document.body.click()
                     }}>

--- a/baby-gru/src/components/webMG/MoorhenWebMG.js
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.js
@@ -93,23 +93,23 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
     }, [props.commandCentre, props.molecules])
 
     const clearHBonds = useCallback(async (e) => {
-        if(!props.drawInteractions) {
+        if(!props.preferences.drawInteractions) {
             props.molecules.forEach(mol => {
                 mol.drawGemmiAtomPairs(glRef, [], "originNeighboursBump", [1.0, 0.0, 0.0, 1.0], true, true)
                 mol.drawGemmiAtomPairs(glRef, [], "originNeighboursHBond", [1.0, 0.0, 0.0, 1.0], true, true)
             })
         }
-    }, [props.drawInteractions, props.molecules])
+    }, [props.preferences.drawInteractions, props.molecules])
 
     const handleOriginUpdate = useCallback(async (e) => {
         hBondsDirty.current = true
-        if (!busyDrawingHBonds.current && props.drawInteractions) {
+        if (!busyDrawingHBonds.current && props.preferences.drawInteractions) {
             drawHBonds()
         }
-    }, [drawHBonds, props.drawInteractions])
+    }, [drawHBonds, props.preferences.drawInteractions])
 
     useEffect(() => {
-        if(props.drawInteractions){
+        if(props.preferences.drawInteractions){
             hBondsDirty.current = true
             if (!busyDrawingHBonds.current) {
                 drawHBonds()
@@ -117,28 +117,28 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
         } else {
             clearHBonds()
         }
-    }, [props.drawInteractions, props.molecules])
+    }, [props.preferences.drawInteractions, props.molecules])
 
     useEffect(() => {
-        glRef.current.doPerspectiveProjection = props.doPerspectiveProjection
+        glRef.current.doPerspectiveProjection = props.preferences.doPerspectiveProjection
         glRef.current.clearTextPositionBuffers()
         glRef.current.drawScene()
-    }, [props.doPerspectiveProjection])
+    }, [props.preferences.doPerspectiveProjection])
 
     useEffect(() => {
-        glRef.current.setShadowDepthDebug(props.doShadowDepthDebug)
+        glRef.current.setShadowDepthDebug(props.preferences.doShadowDepthDebug)
         glRef.current.drawScene()
-    }, [props.doShadowDepthDebug])
+    }, [props.preferences.doShadowDepthDebug])
 
     useEffect(() => {
-        glRef.current.setShadowsOn(props.doShadow)
+        glRef.current.setShadowsOn(props.preferences.doShadow)
         glRef.current.drawScene()
-    }, [props.doShadow])
+    }, [props.preferences.doShadow])
 
     useEffect(() => {
-        glRef.current.useOffScreenBuffers = props.useOffScreenBuffers
+        glRef.current.useOffScreenBuffers = props.preferences.useOffScreenBuffers
         glRef.current.drawScene()
-    }, [props.useOffScreenBuffers])
+    }, [props.preferences.useOffScreenBuffers])
 
     const handleScoreUpdates = useCallback(async (e) => {
         if (e.detail?.modifiedMolecule !== null && connectedMolNo && connectedMolNo.molecule === e.detail.modifiedMolecule) {
@@ -393,11 +393,11 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
     useEffect(() => {
         if (glRef.current) {
-            glRef.current.clipCapPerfectSpheres = props.clipCap
+            glRef.current.clipCapPerfectSpheres = props.preferences.clipCap
             glRef.current.drawScene()
         }
     }, [
-        props.clipCap,
+        props.preferences.clipCap,
         glRef.current
     ])
 
@@ -413,11 +413,11 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
 
     useEffect(() => {
         if (glRef.current) {
-            glRef.current.atomLabelDepthMode = props.atomLabelDepthMode
+            glRef.current.atomLabelDepthMode = props.preferences.atomLabelDepthMode
             glRef.current.drawScene()
         }
     }, [
-        props.atomLabelDepthMode,
+        props.preferences.atomLabelDepthMode,
         glRef.current
     ])
 
@@ -487,8 +487,8 @@ export const MoorhenWebMG = forwardRef((props, glRef) => {
                     showAxes={props.preferences.drawAxes}
                     showFPS={props.preferences.drawFPS}
                     mapLineWidth={mapLineWidth}
-                    drawMissingLoops={props.drawMissingLoops}
-                    drawInteractions={props.drawInteractions} />
+                    drawMissingLoops={props.preferences.drawMissingLoops}
+                    drawInteractions={props.preferences.drawInteractions} />
 
                 {showContextMenu &&
                 <MoorhenContextMenu 

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.js
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.js
@@ -266,13 +266,10 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         const theMatrix = quatToMat4(invQuat);
         const yshift = vec3Create([0, 4. / getDeviceScale(), 0]);
         vec3.transformMat4(yshift, yshift, theMatrix);
-        glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
-        glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
-        glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const scoresUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: glRef.current.origin,  modifiedMolecule: null} })
-        document.dispatchEvent(scoresUpdateEvent);    
-        glRef.current.drawSceneDirty();
-        glRef.current.reContourMaps();
+        const x = glRef.current.origin[0] + (yshift[0] / 8. * glRef.current.zoom)
+        const y = glRef.current.origin[1] + (yshift[1] / 8. * glRef.current.zoom)
+        const z = glRef.current.origin[2] + (yshift[2] / 8. * glRef.current.zoom)
+        glRef.current.setOrigin([x, y, z], true, true)
     }
 
     else if (action === 'move_down') {
@@ -281,13 +278,10 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         const theMatrix = quatToMat4(invQuat);
         const yshift = vec3Create([0, -4. / getDeviceScale(), 0]);
         vec3.transformMat4(yshift, yshift, theMatrix);
-        glRef.current.origin[0] += yshift[0] / 8. * glRef.current.zoom;
-        glRef.current.origin[1] += yshift[1] / 8. * glRef.current.zoom;
-        glRef.current.origin[2] += yshift[2] / 8. * glRef.current.zoom;
-        const scoresUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: glRef.current.origin} })
-        document.dispatchEvent(scoresUpdateEvent);    
-        glRef.current.drawSceneDirty();
-        glRef.current.reContourMaps();
+        const x = glRef.current.origin[0] + (yshift[0] / 8. * glRef.current.zoom);
+        const y = glRef.current.origin[1] + (yshift[1] / 8. * glRef.current.zoom);
+        const z = glRef.current.origin[2] + (yshift[2] / 8. * glRef.current.zoom);
+        glRef.current.setOrigin([x, y, z], true, true)
     }
 
     else if (action === 'move_left') {
@@ -296,13 +290,10 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         const theMatrix = quatToMat4(invQuat);
         const xshift = vec3Create([-4. / getDeviceScale(), 0, 0]);
         vec3.transformMat4(xshift, xshift, theMatrix);
-        glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
-        glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
-        glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const scoresUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: glRef.current.origin} })
-        document.dispatchEvent(scoresUpdateEvent);    
-        glRef.current.drawSceneDirty();
-        glRef.current.reContourMaps();
+        const x = glRef.current.origin[0] + (xshift[0] / 8. * glRef.current.zoom)
+        const y = glRef.current.origin[1] + (xshift[1] / 8. * glRef.current.zoom)
+        const z = glRef.current.origin[2] + (xshift[2] / 8. * glRef.current.zoom)
+        glRef.current.setOrigin([x, y, z], true, true)
     }
 
     else if (action === 'move_right') {
@@ -311,13 +302,10 @@ export const babyGruKeyPress = (event, collectedProps, shortCuts) => {
         const theMatrix = quatToMat4(invQuat);
         const xshift = vec3Create([4. / getDeviceScale(), 0, 0]);
         vec3.transformMat4(xshift, xshift, theMatrix);
-        glRef.current.origin[0] += xshift[0] / 8. * glRef.current.zoom;
-        glRef.current.origin[1] += xshift[1] / 8. * glRef.current.zoom;
-        glRef.current.origin[2] += xshift[2] / 8. * glRef.current.zoom;
-        const scoresUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: glRef.current.origin} })
-        document.dispatchEvent(scoresUpdateEvent);    
-        glRef.current.drawSceneDirty();
-        glRef.current.reContourMaps();
+        const x = glRef.current.origin[0] + (xshift[0] / 8. * glRef.current.zoom)
+        const y = glRef.current.origin[1] + (xshift[1] / 8. * glRef.current.zoom)
+        const z = glRef.current.origin[2] + (xshift[2] / 8. * glRef.current.zoom)
+        glRef.current.setOrigin([x, y, z], true, true)
     }
 
     else if (action === 'restore_scene') {


### PR DESCRIPTION
This update includes:
- More options to the search bar
- Maps are only re-contoured on mouse up when panning the view
- Improved performance when jumping to next residue or centering on an atom: `originUpdate` events were dispatched several times causing some delays.