### PR TITLE
Changed default react app metadata to Moorhen

### DIFF
--- a/baby-gru/public/manifest.json
+++ b/baby-gru/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Moorhen",
+  "name": "Moorhen",
   "icons": [
     {
       "src": "favicon.ico",


### PR DESCRIPTION
Deployed version of Moorhen contains Create React App Boilerplate, I have changed this to better reflect the application (i.e. to Moorhen). 

Before
![Deployed](https://github.com/stuartjamesmcnicholas/Moorhen/assets/44945647/e847ed7e-c9c1-454e-a3b4-ab1adeabda3f)

After
![Proposed Change](https://github.com/stuartjamesmcnicholas/Moorhen/assets/44945647/13970d15-2cac-4bfe-a5b9-16072790d42c)
