### PR TITLE
Add option to not auto-clear atom pull restraints and other requested changes

### DIFF
--- a/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
@@ -25,6 +25,14 @@ const MoorhenPopoverOptions = (props: {
             props.setShowOverlay(false)
         }
     }, [])
+
+    const handleClick = useCallback(() => {
+        if (!props.nonCootCommand) {
+            props.doEdit(props.getCootCommandInput(props.selectedMolecule, props.chosenAtom, selectRef.current.value, extraInputRef))
+        } else {
+            props.nonCootCommand(props.selectedMolecule, props.chosenAtom, selectRef.current.value)
+        }
+      }, [props])
     
     useEffect(() => {
         document.addEventListener("rightClick", handleRightClick);
@@ -44,13 +52,7 @@ const MoorhenPopoverOptions = (props: {
                 </FormSelect>
             </FormGroup>
             {props.extraInput(extraInputRef)}
-            <Button onClick={() => {
-                if (!props.nonCootCommand) {
-                    props.doEdit(props.getCootCommandInput(props.selectedMolecule, props.chosenAtom, selectRef.current.value, extraInputRef))
-                } else {
-                    props.nonCootCommand(props.selectedMolecule, props.chosenAtom, selectRef.current.value)
-                }
-              }}>
+            <Button onClick={handleClick}>
                 OK
             </Button>
         </Stack>
@@ -129,7 +131,7 @@ export const MoorhenContextButtonBase = (props: {
         props.setShowContextMenu(false)
     }
   
-    const handleClick = async () => {
+    const handleClick = useCallback(async () => {
       if (props.popoverSettings) {
         props.setOverlayContents(
           <MoorhenPopoverOptions {...props.popoverSettings} chosenAtom={props.chosenAtom} selectedMolecule={props.selectedMolecule} showContextMenu={props.showContextMenu} doEdit={doEdit} setShowOverlay={props.setShowOverlay}/>
@@ -137,15 +139,15 @@ export const MoorhenContextButtonBase = (props: {
         setTimeout(() => props.setShowOverlay(true), 50)
       } else if (props.nonCootCommand) {
         await props.nonCootCommand(props.selectedMolecule, props.chosenAtom)
-      } else {
+      } else if (props.cootCommandInput) {
         await doEdit(props.cootCommandInput)
       }
-    }
+    }, [props])
     
     return <>
         <IconButton 
             onClick={handleClick}
-            onMouseEnter={(evt) => props.setToolTip(props.toolTipLabel)}
+            onMouseEnter={() => props.setToolTip(props.toolTipLabel)}
             style={{width:'3rem', height: '3rem', marginTop: '0.5rem', paddingRight: 0, paddingTop: 0, paddingBottom: 0, paddingLeft: '0.1rem'}}
             disabled={props.needsMapData && !props.activeMap || (props.needsAtomData && props.molecules.length === 0)}
         >

--- a/baby-gru/src/components/button/MoorhenRigidBodyFitButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRigidBodyFitButton.tsx
@@ -105,10 +105,6 @@ export const MoorhenRigidBodyFitButton = (props: moorhen.EditButtonProps | moorh
             command = 'rigid_body_fit'
         }
 
-        console.log('HI THERE')
-        console.log(selectedMolecule.molNo, chosenAtom.cid, selectedMode, props.activeMap.molNo, command)
-
-
         return {
             message: 'coot_command',
             returnType: "status",

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -140,19 +140,19 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
                 <em>{props.shortCuts ? `Hold ${getTooltipShortcutLabel(JSON.parse(props.shortCuts as string).residue_camera_wiggle)} to move view` : null}</em>
                 <br></br>
                 <br></br>
-                <Stack direction='horizontal' gap={2}>
-                <Button onClick={async () => {
-                        await acceptTransform()
-                        props.setOverrideMenuContents(false)
-                        props.setOpacity(1)
-                        props.setShowContextMenu(false)
-                    }}><CheckOutlined /></Button>
-                <Button onClick={async() => {
-                        await rejectTransform()
-                        props.setOverrideMenuContents(false)
-                        props.setOpacity(1)
-                        props.setShowContextMenu(false)
-                }}><CloseOutlined /></Button>
+                <Stack direction='horizontal' gap={2} style={{ alignItems: 'center',  alignContent: 'center', justifyContent: 'center'}}>
+                    <Button onClick={async () => {
+                            await acceptTransform()
+                            props.setOverrideMenuContents(false)
+                            props.setOpacity(1)
+                            props.setShowContextMenu(false)
+                        }}><CheckOutlined /></Button>
+                    <Button onClick={async() => {
+                            await rejectTransform()
+                            props.setOverrideMenuContents(false)
+                            props.setOpacity(1)
+                            props.setShowContextMenu(false)
+                    }}><CloseOutlined /></Button>
                 </Stack>
             </Card.Body>
             </Card>
@@ -217,14 +217,16 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
                                 <Card.Header >Accept rotate/translate ?</Card.Header>
                                 <Card.Body style={{ alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
                                     {tips}
-                                    <Button onClick={async () => {
-                                        await acceptTransform()
-                                        setShowAccept(false)
-                                    }}><CheckOutlined /></Button>
-                                    <Button className="mx-2" onClick={async() => {
-                                        await rejectTransform()
-                                        setShowAccept(false)
-                                    }}><CloseOutlined /></Button>
+                                    <Stack direction='horizontal' gap={1} style={{ alignItems: 'center',  alignContent: 'center', justifyContent: 'center'}}>
+                                        <Button onClick={async () => {
+                                            await acceptTransform()
+                                            setShowAccept(false)
+                                        }}><CheckOutlined /></Button>
+                                        <Button className="mx-2" onClick={async() => {
+                                            await rejectTransform()
+                                            setShowAccept(false)
+                                        }}><CloseOutlined /></Button>
+                                    </Stack>
                                 </Card.Body>
                             </Card>
                         </div>

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -185,7 +185,7 @@ export const MoorhenContextMenu = (props: {
   }
 
   return <>
-      <ContextMenu ref={contextMenuRef} top={menuPosition.top} left={menuPosition.left} backgroundColor={backgroundColor} opacity={opacity}>
+      <ContextMenu ref={contextMenuRef} top={overrideMenuContents ? convertRemToPx(4) : menuPosition.top} left={overrideMenuContents ? convertRemToPx(2) : menuPosition.left} backgroundColor={backgroundColor} opacity={opacity}>
         {overrideMenuContents ? 
         overrideMenuContents 
         :

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -236,12 +236,19 @@ export namespace libcootApi {
         seqNum: number;
         restype: string;
         value: number;
+        label?: string;
     }
     interface SuperposeResultsT extends emscriptem.instance<SuperposeResultsT> {
         superpose_info: string;
         alignment: PairType<string, string>;
         alignment_info_vec: emscriptem.vector<ValidationInformationT>;
         aligned_pairs: emscriptem.vector<PairType<ResidueValidationInformationT, ResidueValidationInformationT>>;
+    }
+    type SuperposeResultsJS = {
+        referenceSequence: string,
+        movingSequence: string,
+        supperposeInfo: string,
+        alignedPairsData: {reference: ValidationInformationJS, moving: ValidationInformationJS}[],
     }
     interface InstancedDataType extends emscriptem.instance<InstancedDataType> {
         position: [number, number, number];


### PR DESCRIPTION
This update includes:

- Auto-clear atom pull restraints when dragging atoms can now be controlled by user input
- When using the context menu, when a draggable popover appears it will be rendered on one corner to not obstruct the view.
- Other cosmetic changes to context menu panels.
- Update superpose results parsing in cootWorker.